### PR TITLE
feature/2-controller-support

### DIFF
--- a/BleemSync.Payload/lolhack/20-joystick.rules
+++ b/BleemSync.Payload/lolhack/20-joystick.rules
@@ -1,0 +1,2 @@
+KERNEL=="js0",SUBSYSTEMS=="input",SYMLINK+="input/joystick0"
+KERNEL=="js1",SUBSYSTEMS=="input",SYMLINK+="input/joystick1"

--- a/BleemSync.Payload/lolhack/boot.sh
+++ b/BleemSync.Payload/lolhack/boot.sh
@@ -36,9 +36,10 @@ MOUNT_FAIL=0
 umount /data || MOUNT_FAIL=1 
 umount /gaadata || MOUNT_FAIL=1 
 # Create gaadata and data folders in tmp then mount over original folders
-mkdir -p /tmp/gaadatatmp /tmp/datatmp
+mkdir -p /tmp/gaadatatmp /tmp/datatmp /tmp/udev
 mount -o bind /tmp/gaadatatmp /gaadata || MOUNT_FAIL=1 
 mount -o bind /tmp/datatmp /data || MOUNT_FAIL=1 
+mount -o bind /media/lolhack/20-joystick.rules /etc/udev/rules.d/20-joystick.rules || MOUNT_FAIL=1 
 [ $MOUNT_FAIL -eq 1 ] && reboot && exit
 
 # Create gaadata on tmpfs
@@ -63,6 +64,11 @@ ln -s /usr/sony/bin/plugins /tmp/datatmp/AppData/sony/pcsx/plugins
 
 # Fix for last selected game issue. If not in place user may experience UI issue
 sed -i "s/iUiUserSettingLastSelectGameCursorPos.*/iUiUserSettingLastSelectGameCursorPos=0/" /tmp/datatmp/AppData/sony/ui/user.pre
+
+# Reload udev rules that were overmounted above
+# Allows both controllers to be detected through a USB hub
+udevadm control --reload-rules
+udevadm trigger
 
 # Fix for line endings. BAD WINDOWS
 find /media -name *.cfg -exec sed -i 's/\r//g' {} \;

--- a/BleemSync.Payload/lolhack/boot.sh
+++ b/BleemSync.Payload/lolhack/boot.sh
@@ -65,7 +65,7 @@ ln -s /usr/sony/bin/plugins /tmp/datatmp/AppData/sony/pcsx/plugins
 # Fix for last selected game issue. If not in place user may experience UI issue
 sed -i "s/iUiUserSettingLastSelectGameCursorPos.*/iUiUserSettingLastSelectGameCursorPos=0/" /tmp/datatmp/AppData/sony/ui/user.pre
 
-# Reload udev rules that were overmounted above
+# Reload and apply udev rules that were overmounted above
 # Allows both controllers to be detected through a USB hub
 udevadm control --reload-rules
 udevadm trigger

--- a/BleemSync.Payload/lolhack/boot.sh
+++ b/BleemSync.Payload/lolhack/boot.sh
@@ -36,7 +36,7 @@ MOUNT_FAIL=0
 umount /data || MOUNT_FAIL=1 
 umount /gaadata || MOUNT_FAIL=1 
 # Create gaadata and data folders in tmp then mount over original folders
-mkdir -p /tmp/gaadatatmp /tmp/datatmp /tmp/udev
+mkdir -p /tmp/gaadatatmp /tmp/datatmp
 mount -o bind /tmp/gaadatatmp /gaadata || MOUNT_FAIL=1 
 mount -o bind /tmp/datatmp /data || MOUNT_FAIL=1 
 mount -o bind /media/lolhack/20-joystick.rules /etc/udev/rules.d/20-joystick.rules || MOUNT_FAIL=1 


### PR DESCRIPTION
Adds the necessary udev rules to allow both controllers to be detected, through the use of a USB hub