### PR TITLE
Added BleemSync USB drive validator.

### DIFF
--- a/BleemSync.Validator/BleemSync.Validator.csproj
+++ b/BleemSync.Validator/BleemSync.Validator.csproj
@@ -1,0 +1,12 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Folder Include="Services\" />
+  </ItemGroup>
+
+</Project>

--- a/BleemSync.Validator/Program.cs
+++ b/BleemSync.Validator/Program.cs
@@ -1,0 +1,68 @@
+﻿using BleemSync.Validator.Services;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+
+namespace BleemSync.Validator
+{
+    internal static class Program
+    {
+        private static void Main(string[] args)
+        {
+            var drives = DriveInfo
+                .GetDrives()
+                .Where(d => d.DriveType == DriveType.Removable)
+                .ToList();
+
+            if (!drives.Any())
+            {
+                Console.WriteLine("No USB drives attached.");
+                Console.Read();
+                return;
+            }
+
+            var selectedDrive = SelectDrive(drives);
+
+            try
+            {
+                Console.WriteLine($"==== Validating '{selectedDrive}' ====");
+
+                var validator = new ValidationService(selectedDrive);
+                validator.Validate();
+            }
+            catch (Exception e)
+            {
+                Console.ForegroundColor = ConsoleColor.Red;
+                Console.WriteLine(e.Message);
+                Console.ResetColor();
+            }
+            finally
+            {
+                Console.WriteLine("==== Validation complete ====");
+                Console.Read();
+            }
+        }
+
+        private static string SelectDrive(IReadOnlyCollection<DriveInfo> drives)
+        {
+            if (drives.Count == 1) return drives.First().Name;
+
+            Console.WriteLine($"{drives.Count} USB drives found, please type the letter of the drive to validate.");
+            foreach (var drive in drives)
+            {
+                Console.WriteLine(drive.Name);
+            }
+
+            var selectedDrive = "";
+
+            do
+            {
+                selectedDrive = Console.ReadKey(true).Key.ToString();
+            } while (!drives.Any(d =>
+                d.Name.StartsWith(selectedDrive, StringComparison.InvariantCultureIgnoreCase)));
+
+            return selectedDrive.ToUpper() + ":\\";
+        }
+    }
+}

--- a/BleemSync.Validator/Services/ValidationService.cs
+++ b/BleemSync.Validator/Services/ValidationService.cs
@@ -1,0 +1,88 @@
+﻿using BleemSync.Validator.Validators;
+using System;
+using System.Collections.Generic;
+using System.IO;
+
+namespace BleemSync.Validator.Services
+{
+    public class ValidationService
+    {
+        private readonly IEnumerable<IValidator> _validators;
+        
+        public ValidationService(string letter)
+        {
+            _validators = new List<IValidator>
+            {
+                new DriveFormatValidator(letter),
+                new DriveNameValidator(letter),
+                new BleemSystemValidator(letter),
+                new GamesValidator(letter)
+            };
+
+            var drive = new DriveInfo(letter);
+            if (!drive.IsReady) throw new DriveNotFoundException($"Drive '{letter}' not ready.");
+        }
+
+        public void Validate()
+        {
+            foreach (var validator in _validators)
+            {
+                ProcessValidator(validator);
+            }
+        }
+
+        private static void ProcessValidator(IValidator validator, int depth = 0)
+        {
+            validator.Validate();
+            ReportValidation(validator, depth);
+
+            depth +=4;
+
+            foreach (var child in validator.Validators)
+            {
+                ProcessValidator(child, depth);
+            }
+        }
+
+        private static void ReportValidation(IValidator validator, int depth = 0)
+        {
+            var left = "".PadLeft(depth, ' ');
+
+            Console.Write($"{left}{"".PadRight(6, '=')} {validator.Title}: ");
+
+            WriteStatus(validator);
+
+            foreach (var message in validator.Messages)
+            {
+                Console.WriteLine($"{left}{message}");
+            }
+
+            Console.WriteLine($"{left}".PadRight(100, '-'));
+        }
+
+        private static void WriteStatus(IValidator validator)
+        {
+            switch (validator.Status)
+            {
+                case ValidationStatus.Pending:
+                    Console.ForegroundColor = ConsoleColor.Gray;
+                    break;
+                case ValidationStatus.Pass:
+                    Console.ForegroundColor = ConsoleColor.Green;
+                    break;
+                case ValidationStatus.Warn:
+                    Console.ForegroundColor = ConsoleColor.Yellow;
+                    break;
+                case ValidationStatus.Fail:
+                    Console.ForegroundColor = ConsoleColor.Red;
+                    break;
+                default:
+                    Console.ForegroundColor = ConsoleColor.White;
+                    break;
+            }
+
+            Console.Write($"{validator.Status}\r\n");
+            Console.ResetColor();
+        }
+    }
+}

--- a/BleemSync.Validator/Validators/BleemSystemValidator.cs
+++ b/BleemSync.Validator/Validators/BleemSystemValidator.cs
@@ -1,0 +1,47 @@
+﻿using System.IO;
+
+namespace BleemSync.Validator.Validators
+{
+    public class BleemSystemValidator : Validator
+    {
+        public override string Title => $"Checking for Bleem artifacts in root of '{DirPath}'";
+
+        public BleemSystemValidator(string path) : base(path) { }
+
+        public override void Validate()
+        {
+            var valid = FolderExists("028c18a9-ec4b-4632-b2cf-d4e20f252e8f") &
+                        FileExists("028c18a9-ec4b-4632-b2cf-d4e20f252e8f", "LUPDATA.BIN") &
+                        FolderExists("lolhack") &
+                        FileExists("lolhack", "20-joystick.rules") &
+                        FileExists("lolhack", "boot.sh") &
+                        FileExists("lolhack", "lolhack.sh") &
+                        FolderExists("System") &
+                        FolderExists("Games") &
+                        FolderExists("System\\Databases") &
+                        FileExists("System\\Databases", "regional.db");
+
+            Messages.Add(valid
+                ? "Required Bleem artifacts are present."
+                : "Not all required Bleem artifacts are present.");
+
+            Status = valid ? ValidationStatus.Pass : ValidationStatus.Fail;
+        }
+
+        private bool FolderExists(string name)
+        {
+            if (Directory.Exists(Path.Join(DirPath, name))) return true;
+            Messages.Add($"Folder '{name}' does not exist in '{DirPath}'.");
+            return false;
+        }
+
+        private bool FileExists(string path, string name)
+        {
+            var filePath = Path.Join(DirPath, path);
+
+            if (File.Exists(Path.Join(filePath, name))) return true;
+            Messages.Add($"File '{name}' does not exist in '{filePath}'.");
+            return false;
+        }
+    }
+}

--- a/BleemSync.Validator/Validators/DriveFormatValidator.cs
+++ b/BleemSync.Validator/Validators/DriveFormatValidator.cs
@@ -1,0 +1,25 @@
+﻿using System.IO;
+
+namespace BleemSync.Validator.Validators
+{
+    public class DriveFormatValidator : Validator
+    {
+        public override string Title => $"Checking drive format of '{DirPath}'";
+        
+        public DriveFormatValidator(string path) : base(path) { }
+
+        public override void Validate()
+        {
+            var driveInfo = new DriveInfo(DirPath);
+
+            var valid = driveInfo.DriveFormat.Equals("FAT32") ||
+                        driveInfo.DriveFormat.Equals("exFAT");
+
+            Messages.Add(valid
+                ? $"Drive format '{driveInfo.DriveFormat}' is valid."
+                : $"Drive format '{driveInfo.DriveFormat}' is invalid. Valid formats 'FAT32', 'exFAT'");
+
+            Status = valid ? ValidationStatus.Pass : ValidationStatus.Fail;
+        }
+    }
+}

--- a/BleemSync.Validator/Validators/DriveNameValidator.cs
+++ b/BleemSync.Validator/Validators/DriveNameValidator.cs
@@ -1,0 +1,24 @@
+﻿using System.IO;
+
+namespace BleemSync.Validator.Validators
+{
+    public class DriveNameValidator : Validator
+    {
+        public override string Title => $"Checking '{DirPath}' is named 'SONY'";
+
+        public DriveNameValidator(string path) : base(path) { }
+
+        public override void Validate()
+        {
+            var driveInfo = new DriveInfo(DirPath);
+
+            var valid = driveInfo.VolumeLabel.Equals("SONY");
+
+            Messages.Add(valid
+                ? $"Drive is named 'SONY'."
+                : $"Drive must be named 'SONY'.");
+
+            Status = valid ? ValidationStatus.Pass : ValidationStatus.Fail;
+        }
+    }
+}

--- a/BleemSync.Validator/Validators/GameValidator.cs
+++ b/BleemSync.Validator/Validators/GameValidator.cs
@@ -1,0 +1,209 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+
+namespace BleemSync.Validator.Validators
+{
+    public class GameValidator : Validator
+    {
+        private readonly IEnumerable<FileInfo> _gameFiles;
+        private readonly IEnumerable<FileInfo> _binFiles;
+        private readonly IEnumerable<FileInfo> _cueFiles;
+
+        public override string Title => $"Validating folder structure for '{DirPath}'";
+
+        public GameValidator(string path) : base(path)
+        {
+            _gameFiles = new DirectoryInfo(Path.Join(DirPath, "GameData"))
+                .GetFiles();
+
+            _binFiles = _gameFiles
+                .Where(f => f.Extension.Equals(".bin", StringComparison.InvariantCultureIgnoreCase))
+                .ToList();
+
+            _cueFiles = _gameFiles
+                .Where(f => f.Extension.Equals(".cue", StringComparison.InvariantCultureIgnoreCase))
+                .ToList();
+        }
+
+        public override void Validate()
+        {
+            if (!Directory.Exists(Path.Join(DirPath, "GameData")))
+            {
+                Messages.Add("Could not find 'GameData' folder.");
+                Status = ValidationStatus.Fail;
+                return;
+            }
+            
+            var gameChecks = new List<ValidationStatus>();
+            gameChecks.AddRange(ExtensionsExist());
+            gameChecks.AddRange(FilesExist());
+            gameChecks.Add(BinFileNamesValid());
+            gameChecks.AddRange(MatchBinsWithCues());
+            gameChecks.AddRange(CueContentsValid());
+            gameChecks.Add(GameIniContentsValid());
+
+            Status = GetValidationStatus(gameChecks);
+
+            if(Status == ValidationStatus.Pass) Messages.Add("Game validated successfully.");
+        }
+
+        private IEnumerable<ValidationStatus> ExtensionsExist()
+        {
+            if (!_gameFiles.Any())
+            {
+                yield return ValidationStatus.Fail;
+                yield break;
+            }
+
+            var extensionChecks = new Dictionary<string, ValidationStatus>
+            {
+                {".bin", ValidationStatus.Fail},
+                {".cue", ValidationStatus.Fail},
+                {".png", ValidationStatus.Warn}
+            };
+
+            foreach (var (extension, status) in extensionChecks)
+            {
+                if (_gameFiles.Any(f => f.Extension.Equals(extension, StringComparison.InvariantCultureIgnoreCase)))
+                {
+                    yield return ValidationStatus.Pass;
+                    continue;
+                };
+
+                Messages.Add($"Could not find any '{extension}' file(s).");
+                yield return status;
+            }
+        }
+
+        private IEnumerable<ValidationStatus> FilesExist()
+        {
+            if (!_gameFiles.Any())
+            {
+                yield return ValidationStatus.Fail;
+                yield break;
+            }
+
+            var fileChecks = new Dictionary<string, ValidationStatus>
+            {
+                {"Game.ini", ValidationStatus.Fail},
+                {"pcsx.cfg", ValidationStatus.Fail}
+            };
+
+            foreach (var (fileName, status) in fileChecks)
+            {
+                if (_gameFiles.Any(f => f.Name.Equals(fileName, StringComparison.InvariantCultureIgnoreCase)))
+                {
+                    yield return ValidationStatus.Pass;
+                    continue;
+                }
+
+                Messages.Add($"Could not find file '{fileName}'.");
+                yield return status;
+            }
+        }
+
+        private ValidationStatus BinFileNamesValid()
+        {
+            if (!_binFiles.Any()) return ValidationStatus.Fail;
+
+            var binNames = _binFiles
+                .Select(n => Path.GetFileNameWithoutExtension(n.Name))
+                .ToList();
+            
+            if (!binNames.Any(b => b.Contains(',') || b.Contains('.'))) return ValidationStatus.Pass;
+
+            Messages.Add("'.bin' files must not contain ',' or '.' in name.");
+            return ValidationStatus.Fail;
+        }
+
+        private IEnumerable<ValidationStatus> MatchBinsWithCues()
+        {
+            if (!_binFiles.Any() || !_cueFiles.Any())
+            {
+                yield return ValidationStatus.Fail;
+                yield break;
+            }
+
+            var binNames = _binFiles
+                .Select(n => Path.GetFileNameWithoutExtension(n.Name))
+                .ToList();
+
+            var cueNames = _cueFiles
+                .Select(n => Path.GetFileNameWithoutExtension(n.Name))
+                .ToList();
+
+            foreach (var name in binNames)
+            {
+                if (cueNames.Any(c => c.Equals(name)))
+                {
+                    yield return ValidationStatus.Pass;
+                    continue;
+                };
+
+                Messages.Add($"The '.bin' file '{name}' does not have a matching '.cue' file.");
+                yield return ValidationStatus.Fail;
+            }
+        }
+
+        private IEnumerable<ValidationStatus> CueContentsValid()
+        {
+            if (!_cueFiles.Any())
+            {
+                yield return ValidationStatus.Fail;
+                yield break;
+            }
+
+            foreach (var cue in _cueFiles)
+            {
+                var cueName = Path.GetFileNameWithoutExtension(cue.Name);
+                var cueFileLine = File
+                    .ReadAllLines(cue.FullName)
+                    .FirstOrDefault(line => line.StartsWith("FILE"));
+
+                if (cueFileLine?.Contains($"\"{cueName}\"") == true)
+                {
+                    yield return ValidationStatus.Pass;
+                    continue;
+                };
+
+                Messages.Add(
+                    $"The contents of the '.cue' file '{cue.Name}' does not start with 'FILE \"{cueName}\" BINARY'.");
+                yield return ValidationStatus.Fail;
+            }
+        }
+
+        private ValidationStatus GameIniContentsValid()
+        {
+            if (!_gameFiles.Any() || !_cueFiles.Any()) return ValidationStatus.Fail;
+
+            var cueNames = _cueFiles
+                .Select(n => Path.GetFileNameWithoutExtension(n.Name))
+                .ToList();
+
+            var iniFile = _gameFiles
+                .FirstOrDefault(f => f.Name.Equals("Game.ini", StringComparison.InvariantCultureIgnoreCase));
+
+            if (!cueNames.Any() || iniFile == null) return ValidationStatus.Fail;
+
+            var iniDiscLine = File
+                .ReadAllLines(iniFile.FullName)
+                .FirstOrDefault(line => line.StartsWith("Discs"));
+            
+            if (iniDiscLine == null) return ValidationStatus.Fail;
+
+            if (cueNames.All(c => iniDiscLine.Contains(c))) return ValidationStatus.Pass;
+
+            Messages.Add(
+                $"The contents of the 'Game.ini' file is incorrect. Discs line does not list all '.cue' files in the game directory. Try modifying to 'Discs={string.Join(",", cueNames)}'");
+            return ValidationStatus.Fail;
+        }
+
+        private static ValidationStatus GetValidationStatus(IList<ValidationStatus> statuses)
+        {
+            if (statuses.Any(s => s == ValidationStatus.Fail)) return ValidationStatus.Fail;
+            return statuses.Any(s => s == ValidationStatus.Warn) ? ValidationStatus.Warn : ValidationStatus.Pass;
+        }
+    }
+}

--- a/BleemSync.Validator/Validators/GamesValidator.cs
+++ b/BleemSync.Validator/Validators/GamesValidator.cs
@@ -1,0 +1,31 @@
+﻿using System.IO;
+using System.Linq;
+
+namespace BleemSync.Validator.Validators
+{
+    public class GamesValidator : Validator
+    {
+        public override string Title => "Checking game folders";
+
+        public GamesValidator(string path) : base(path) { }
+
+        public override void Validate()
+        {
+            var games = Directory.GetDirectories(System.IO.Path.Join(DirPath, "Games"));
+            
+            foreach (var gamePath in games)
+            {
+                var validator = new GameValidator(gamePath);
+                Validators.Add(validator);
+            }
+
+            var valid = Validators.All(v => v.Status == ValidationStatus.Pass);
+
+            Messages.Add(valid 
+                ? "Games validated successfully." 
+                : "Games not validated successfully. Some or all of your games may not work.");
+
+            Status = valid ? ValidationStatus.Pass : ValidationStatus.Warn;
+        }
+    }
+}

--- a/BleemSync.Validator/Validators/IValidator.cs
+++ b/BleemSync.Validator/Validators/IValidator.cs
@@ -1,0 +1,13 @@
+﻿using System.Collections.Generic;
+
+namespace BleemSync.Validator.Validators
+{
+    public interface IValidator
+    {
+        string Title { get; }
+        ValidationStatus Status { get; }
+        List<IValidator> Validators { get; }
+        List<string> Messages { get; }
+        void Validate();
+    }
+}

--- a/BleemSync.Validator/Validators/ValidationStatus.cs
+++ b/BleemSync.Validator/Validators/ValidationStatus.cs
@@ -1,0 +1,4 @@
+﻿namespace BleemSync.Validator.Validators
+{
+    public enum ValidationStatus { Pending, Pass, Warn, Fail }
+}

--- a/BleemSync.Validator/Validators/Validator.cs
+++ b/BleemSync.Validator/Validators/Validator.cs
@@ -1,0 +1,23 @@
+﻿using System.Collections.Generic;
+
+namespace BleemSync.Validator.Validators
+{
+    public abstract class Validator : IValidator
+    {
+        public abstract string Title { get; }
+        protected string DirPath { get; }
+        public ValidationStatus Status { get; protected set; }
+        public List<string> Messages { get; }
+        public List<IValidator> Validators { get; }
+
+        protected Validator(string path)
+        {
+            DirPath = path;
+            Status = ValidationStatus.Pending;
+            Messages = new List<string>();
+            Validators = new List<IValidator>();
+        }
+
+        public abstract void Validate();
+    }
+}

--- a/BleemSync.sln
+++ b/BleemSync.sln
@@ -15,9 +15,11 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "BleemSync.Scrapers.PSXDataC
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "BleemSync.Central.Data", "BleemSync.Central.Data\BleemSync.Central.Data.csproj", "{4BBBBD40-706A-4C1D-9693-779EBC1CD255}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "BleemSync.Central", "BleemSync.Central\BleemSync.Central.csproj", "{B6CC05A8-AF80-4298-BB22-451F920E8320}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "BleemSync.Central", "BleemSync.Central\BleemSync.Central.csproj", "{B6CC05A8-AF80-4298-BB22-451F920E8320}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "BleemSync.Central.Services", "BleemSync.Central.Services\BleemSync.Central.Services.csproj", "{6712A24F-CB48-4C3D-91E7-C3C261E98C2B}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "BleemSync.Central.Services", "BleemSync.Central.Services\BleemSync.Central.Services.csproj", "{6712A24F-CB48-4C3D-91E7-C3C261E98C2B}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "BleemSync.Validator", "BleemSync.Validator\BleemSync.Validator.csproj", "{B92AF938-B383-4982-8922-4D38E62FC7E1}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -57,6 +59,10 @@ Global
 		{6712A24F-CB48-4C3D-91E7-C3C261E98C2B}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{6712A24F-CB48-4C3D-91E7-C3C261E98C2B}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{6712A24F-CB48-4C3D-91E7-C3C261E98C2B}.Release|Any CPU.Build.0 = Release|Any CPU
+		{B92AF938-B383-4982-8922-4D38E62FC7E1}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{B92AF938-B383-4982-8922-4D38E62FC7E1}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{B92AF938-B383-4982-8922-4D38E62FC7E1}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{B92AF938-B383-4982-8922-4D38E62FC7E1}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
Hi there,

Awesome work on the tool, it works great.

I see that a lot of the issue that get raised are to do with incorrect configuration of the USB key used with the PSC.

I've added another project that will validate a USB key by checking the following:

1. The format of the key.
2. The name of key is SONY.
3. The required Bleem files and folders are present.
4. Each game folder gets checked by:
        .bin, .cue and .png files are present.
        Game.ini and pcsx.ini files are present.
        Each .bin file has a matching .cue file. 
        Each .cue file contains the name of its matching.bin file.
        Game.ini file Discs line contains the name of each .cue file.

You might want to change the project so that a successful build copies it to the BleemSync bin folder.  Feel free to change it as you want.

I'm happy to make any changes / fix any issues that are raised related to it. I've only tested this on a Windows machine, so may not work so well on other platforms.

Cheers