### PR TITLE
Initial functionality for ui_menu and RetroArch interaction

### DIFF
--- a/Payload/bleemsync/etc/bleemsync/FUNC/0050_bleemsync.funcs
+++ b/Payload/bleemsync/etc/bleemsync/FUNC/0050_bleemsync.funcs
@@ -77,6 +77,12 @@ exit_checkSaveState(){
 	# game
     
     ra_last_game=`ls -t $mountpoint/bleemsync/opt/retroArch/savestates/*.auto | head -1`
+
+	if [ "$ra_last_game" == "" ]; then
+		echo "[BLEEMSYNC](INFO) no auto save state exists"
+		return 0
+	fi
+
     ra_last_game="${ra_last_game##*/}"          #   Remove leading directories
     ra_last_game="${ra_last_game%.state.auto}"  #   Remove trailing file extension .state.auto
 

--- a/Payload/bleemsync/etc/bleemsync/FUNC/0050_bleemsync.funcs
+++ b/Payload/bleemsync/etc/bleemsync/FUNC/0050_bleemsync.funcs
@@ -102,6 +102,8 @@ exit_checkSaveState(){
 			echo "[BLEEMSYNC](INFO) New game path: $intercept_game_path"
             
             echo "[BLEEMSYNC](INFO) New Game ID: $intercept_game_id"
+		else
+			echo "[BLEEMSYNC](INFO) but it does not appear to belong to the game we launched from, so we'll ignore it [${ra_last_game}.${intercept_game_ext}]"
         fi
     fi
 

--- a/Payload/bleemsync/etc/bleemsync/FUNC/0050_bleemsync.funcs
+++ b/Payload/bleemsync/etc/bleemsync/FUNC/0050_bleemsync.funcs
@@ -149,6 +149,47 @@ launch_RetroArch_from_StockUI(){
 
 }
 
+link_ra_memory_cards(){
+
+	##
+	#	WORK IN PROGRESS
+	##
+	return 0
+
+	#	This function will link ui_menu and RetroArch memory cards
+	#	ui_menu memory cards take precedence
+
+	echo "[BLEEMSYNC](INFO) linking ui_menu memory cards to RetroArch"
+
+	if ls -la | grep -i ".pcsx ->"; then
+
+        if [ ! -f /data/AppData/sony/pcsx/.pcsx/memcards/card1.mcd ]; then
+
+            mkdir -p /data/AppData/sony/pcsx/.pcsx/memcards
+            cp /usr/sony/share/data/memcard/card.mcd /data/AppData/sony/pcsx/.pcsx/memcards/card1.mcd
+        fi
+        
+		#	Will this work if $mountpoint is FAT32?
+        ln -sf /data/AppData/sony/pcsx/.pcsx/memcards/card1.mcd $mountpoint/bleemsync/opt/retroArch/saves/${intercept_game_id}.srm
+
+        #   RetroArch creates a memory card per game, which means all possible game discs need to be linked back to
+		#	/data/AppData/sony/pcsx/.pcsx/memcards/card1.mcd for them to function with a shared memory card which can be
+		#	managed from ui_menu
+		#
+        #   This is rather brute force at the moment, but iterate through each file in the directory and create a memory card symlink
+        for e in /data/AppData/sony/title/*; do
+    
+            if [ -f "$e" ]; then
+
+                temp_id="${e##*/}"
+                temp_id="${temp_id%.*}"
+                ln -sf /data/AppData/sony/pcsx/.pcsx/memcards/card1.mcd $mountpoint/bleemsync/opt/retroArch/saves/${temp_id}.srm
+            fi
+        done
+
+    fi
+	
+}
 
 ###############################################################################
 

--- a/Payload/bleemsync/etc/bleemsync/FUNC/0050_bleemsync.funcs
+++ b/Payload/bleemsync/etc/bleemsync/FUNC/0050_bleemsync.funcs
@@ -97,8 +97,6 @@ exit_checkSaveState(){
             
             echo "[BLEEMSYNC](INFO) New Game ID: $intercept_game_id"
         fi
-    else
-        echo "We same game boys"
     fi
 
 	#	Check if an auto save state exists and then move it to the correct location for ui_menu to handle
@@ -120,6 +118,35 @@ exit_checkSaveState(){
 	#	so these need to be removed to ensure things work correctly
     #	F for orphaned auto saves
     rm $mountpoint/bleemsync/opt/retroArch/savestates/*.auto
+}
+
+launch_RetroArch_from_StockUI(){
+
+	echo "[BLEEMSYNC](INFO) launching RetroArch from menu_ui"
+
+	#	Check RA Exists and is configured correctly
+	[ -f "$runtime_log_path/retroarch.log" ] && rm -f "$runtime_log_path/retroarch.log" 
+	[ ! -f "$mountpoint/bleemsync/opt/retroArch/retroarch" ] && break #FAIL
+	if [ ! -f "$mountpoint/bleemsync/opt/retroArch/retroarch/system/scph102b.bin" ]; then
+		cp -f "/gaadata/system/bios/romw.bin" "$mountpoint/bleemsync/opt/retroArch/retroarch/system/scph102b.bin"
+		echo "[BLEEMSYNC](INFO) copied romw.bin to scph102b.bin for RA PCSX"
+	fi
+	mkdir -p "/tmp/ra_cache"
+	chmod +x "$mountpoint/bleemsync/opt/retroArch/retroarch"
+	export HOME="$mountpoint/bleemsync/opt/retroArch"
+
+	#	Check if this is a Save State load
+	if [ "$intercept_save_state" = true ]; then
+		echo "[BLEEMSYNC](INFO) this is a save state load"
+        mv /data/AppData/sony/pcsx/.pcsx/sstates/${intercept_game_id}.000 $mountpoint/bleemsync/opt/retroArch/savestates/${intercept_game_id}.state.auto
+    fi
+
+	#	Launch RetroArch
+	echo "[BLEEMSYNC](INFO) Launching RetroArch for game $intercept_game_path"
+	$mountpoint/bleemsync/opt/retroArch/retroarch -v -L $mountpoint/bleemsync/opt/retroArch/retroarch/.config/retroarch/cores/pcsx_rearmed_libretro.so $intercept_game_path &> "$runtime_log_path/retroarch.log"
+	echo "[BLEEMSYNC](INFO) RetroArch exit code $?"
+	rm -rf "/tmp/ra_cache"
+
 }
 
 

--- a/Payload/bleemsync/etc/bleemsync/FUNC/0050_bleemsync.funcs
+++ b/Payload/bleemsync/etc/bleemsync/FUNC/0050_bleemsync.funcs
@@ -52,6 +52,79 @@ launch_StockUI(){
 }
 ###############################################################################
 
+###	UI_MENU -> RETROARCH INTERACTION FUNCTIONS ################################
+
+#	The follow variables will need to have been gathered from an intercept script
+#	prior to these functions being called
+#
+#
+#	intercept_game_path="" 		# The full path to the launching game file (follows argument -cdfile)
+#	intercept_game_dir="" 		# The directory game launched from - should be /data/AppData/sony/title
+#	intercept_game_id="" 		# The file name of the game minus the extension (ie. SCUS-0001)
+#	intercept_game_ext="" 		# The extension of game minus . (ie. cue)
+#	intercept_save_state=false 	# Set to true if ui_menu launches with -load
+#
+##
+
+exit_checkSaveState(){
+
+	# This function should only be called from the intercept script after RetroArch exits
+
+	echo "[BLEEMSYNC](INFO) checking for auto save state on RetroArch exit"
+
+	# An auto save state is created automatically, but what if the game disc was changed since
+	# RetroArch was originally launched. Check that the last saved state matches the ID of the launching
+	# game
+    
+    ra_last_game=`ls -t $mountpoint/bleemsync/opt/retroArch/savestates/*.auto | head -1`
+    ra_last_game="${ra_last_game##*/}"          #   Remove leading directories
+    ra_last_game="${ra_last_game%.state.auto}"  #   Remove trailing file extension .state.auto
+
+    if [ ! "$ra_last_game" == "$intercept_game_id" ]; then
+        
+		#   The last save state was for a different game, check if this disc belongs to the launching game
+		#	If it does then a disc swap has occured, so update the game ids so the correct save state
+		#	data is passed to ui_menu
+        echo "[BLEEMSYNC](INFO) last auto save state is from a game which is different to the launched game"
+
+        if [ -f "/data/AppData/sony/title/${ra_last_game}.${intercept_game_ext}" ]; then
+
+			echo "[BLEEMSYNC](INFO) ${ra_last_game}.${intercept_game_ext} exists and belongs to the launching game, updating save state"
+            intercept_game_path="/data/AppData/sony/title/${ra_last_game}.${intercept_game_ext}"
+            intercept_game_id=$ra_last_game
+			
+			echo "[BLEEMSYNC](INFO) New game path: $intercept_game_path"
+            
+            echo "[BLEEMSYNC](INFO) New Game ID: $intercept_game_id"
+        fi
+    else
+        echo "We same game boys"
+    fi
+
+	#	Check if an auto save state exists and then move it to the correct location for ui_menu to handle
+
+    if [ -f $mountpoint/bleemsync/opt/retroArch/savestates/${intercept_game_id}.state.auto ]; then
+		echo "[BLEEMSYNC](INFO) an auto save state exists"
+
+		#	Create filename.txt
+        echo $intercept_game_path > /data/AppData/sony/pcsx/.pcsx/filename.txt
+        echo $intercept_game_id >> /data/AppData/sony/pcsx/.pcsx/filename.txt
+
+		#	Move save state files
+        mv $mountpoint/bleemsync/opt/retroArch/savestates/${intercept_game_id}.state.auto /data/AppData/sony/pcsx/.pcsx/sstates/${intercept_game_id}.000
+        mv $mountpoint/bleemsync/opt/retroArch/savestates/${intercept_game_id}.state.auto.png /data/AppData/sony/pcsx/.pcsx/screenshots/${intercept_game_id}.png
+        
+    fi
+
+	#	Remove any remaining auto save states. We're completly hijacking the auto-save state process
+	#	so these need to be removed to ensure things work correctly
+    #	F for orphaned auto saves
+    rm $mountpoint/bleemsync/opt/retroArch/savestates/*.auto
+}
+
+
+###############################################################################
+
 execute_bleemsync_func(){
 	echo "[BLEEMSYNC](Executing) execute_bleemsync_func()"
 	echo 1 > /sys/class/leds/red/brightness

--- a/Payload/bleemsync/etc/bleemsync/FUNC/0050_bleemsync.funcs
+++ b/Payload/bleemsync/etc/bleemsync/FUNC/0050_bleemsync.funcs
@@ -10,7 +10,7 @@ launch_RetroArch(){
 	while true; do
 		killall -s KILL showLogo sonyapp ui_menu auto_dimmer pcsx sdl_display
 		[ ! -d "$mountpoint/bleemsync/opt/retroArch" ] && mkdir -p "$mountpoint/bleemsync/opt/retroarch"
-		[ -d "$runtime_log_path/retroarch.log" ] && rm -f "$runtime_log_path/retroarch.log" 
+		[ -f "$runtime_log_path/retroarch.log" ] && rm -f "$runtime_log_path/retroarch.log" 
 		[ ! -f "$mountpoint/bleemsync/opt/retroArch/retroarch" ] && break #FAIL
 		if [ ! -f "$mountpoint/bleemsync/opt/retroArch/retroarch/system/scph102b.bin" ]; then
 			cp -f "/gaadata/system/bios/romw.bin" "$mountpoint/bleemsync/opt/retroArch/retroarch/system/scph102b.bin"

--- a/Payload/bleemsync/opt/retroarch/.config/retroarch/config/PCSX-ReARMed/title.cfg
+++ b/Payload/bleemsync/opt/retroarch/.config/retroarch/config/PCSX-ReARMed/title.cfg
@@ -1,0 +1,4 @@
+savestate_auto_load = "true"
+savestate_auto_save = "true"
+savestate_thumbnail_enable = "true"
+rgui_browser_directory = "/data/AppData/sony/title"


### PR DESCRIPTION
These are functions for launching RetroArch from ui_menu, and then integrating things like save states and memory cards back into ui_menu. 

In an intercept script, the following variables need to be gathered from the arguments ui_menu passes
```bash
intercept_game_path="" 		# The full path to the launching game file (follows argument -cdfile)
intercept_game_dir="" 		# The directory game launched from - should be /data/AppData/sony/title
intercept_game_id="" 		# The file name of the game minus the extension (ie. SCUS-0001)
intercept_game_ext="" 		# The extension of game minus . (ie. cue)
intercept_save_state=false 	# Set to true if ui_menu launches with -load
```
Then call the following functions from that intercept script
`launch_RetroArch_from_StockUI`
`exit_checkSaveState`

There is a working function for linking memory card files but it may need some additional thought before using - `link_ra_memory_cards` - it should really be called from `launch_RetroArch_from_StockUI`
This creates symlinks from the RetroArch saves directory back to the PCSX memcards directory, so that saves can be managed from ui_menu and used from inside RetroArch. May need additional thought because of symlinking on a fat32 external.

