### PR TITLE
Add RetroArch override to support auto save states

### DIFF
--- a/Payload/bleemsync/opt/retroarch/.config/retroarch/config/PCSX-ReARMed/title.cfg
+++ b/Payload/bleemsync/opt/retroarch/.config/retroarch/config/PCSX-ReARMed/title.cfg
@@ -1,0 +1,6 @@
+savestate_auto_load = "true"
+savestate_auto_save = "true"
+savestate_thumbnail_enable = "true"
+rgui_browser_directory = "/data/AppData/sony/title"
+input_exit_emulator = "menu"
+input_menu_toggle = "tab"


### PR DESCRIPTION
This was originally part of https://github.com/pathartl/BleemSync/pull/183 but I think went missing during the manual pull.

This file is required for the auto save state functionality when Stock UI is using RetroArch as the emulator.

Also, added in bindings so that when RA is being used by Stock UI the RESET button will quit RA (triggering save state creation, and simulates what happens when pcsx is the emulator). OPEN button is set to open the RA menu at the moment, until such time it can be better integrated with the disc swapping features.

These settings only apply when RA is launched by Stock UI.