### PR TITLE
Added ability to user different folder names for games

### DIFF
--- a/BleemSync.Central.Data/BleemSync.Central.Data.csproj
+++ b/BleemSync.Central.Data/BleemSync.Central.Data.csproj
@@ -15,4 +15,8 @@
     <ProjectReference Include="..\BleemSync.Utilities\BleemSync.Utilities.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <RuntimeHostConfigurationOption Include="System.Globalization.Invariant" Value="true" />
+  </ItemGroup>
+
 </Project>

--- a/BleemSync.Central.Data/Game/Game.cs
+++ b/BleemSync.Central.Data/Game/Game.cs
@@ -11,6 +11,7 @@ namespace BleemSync.Central.Data.Models
     {
         [Key]
         public int Id { get; set; }
+	      public String RelativePath { get; set; }
         public string Title { get; set; }
         public string CommonTitle { get; set; }
         public string Region { get; set; }

--- a/BleemSync.Central.Services/BleemSync.Central.Services.csproj
+++ b/BleemSync.Central.Services/BleemSync.Central.Services.csproj
@@ -4,9 +4,14 @@
     <TargetFramework>netcoreapp2.1</TargetFramework>
     <RootNamespace>BleemSync.Central.Services</RootNamespace>
   </PropertyGroup>
-  
+
   <ItemGroup>
     <ProjectReference Include="..\BleemSync.Central.Data\BleemSync.Central.Data.csproj" />
   </ItemGroup>
+
+  <ItemGroup>
+    <RuntimeHostConfigurationOption Include="System.Globalization.Invariant" Value="true" />
+  </ItemGroup>
+
 
 </Project>

--- a/BleemSync.Data/BleemSync.Data.csproj
+++ b/BleemSync.Data/BleemSync.Data.csproj
@@ -17,4 +17,9 @@
     <ProjectReference Include="..\BleemSync.Utilities\BleemSync.Utilities.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <RuntimeHostConfigurationOption Include="System.Globalization.Invariant" Value="true" />
+  </ItemGroup>
+
+
 </Project>

--- a/BleemSync.PSXDataCenterScraper/BleemSync.Scrapers.PSXDataCenterScraper.csproj
+++ b/BleemSync.PSXDataCenterScraper/BleemSync.Scrapers.PSXDataCenterScraper.csproj
@@ -18,4 +18,9 @@
     <ProjectReference Include="..\BleemSync.Central.Data\BleemSync.Central.Data.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <RuntimeHostConfigurationOption Include="System.Globalization.Invariant" Value="true" />
+  </ItemGroup>
+
+
 </Project>

--- a/BleemSync.Services/BleemSync.Services.csproj
+++ b/BleemSync.Services/BleemSync.Services.csproj
@@ -15,4 +15,9 @@
     <ProjectReference Include="..\BleemSync.Data\BleemSync.Data.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <RuntimeHostConfigurationOption Include="System.Globalization.Invariant" Value="true" />
+  </ItemGroup>
+
+
 </Project>

--- a/BleemSync.Services/Classes/GameInfo.cs
+++ b/BleemSync.Services/Classes/GameInfo.cs
@@ -8,6 +8,7 @@ namespace BleemSync.Data.Models
     public class GameInfo
     {
         public int Id { get; set; }
+	      public String RelativePath { get; set; }
         public string Title { get; set; }
         public string Publisher { get; set; }
         public int Year { get; set; }

--- a/BleemSync.Services/GameService.cs
+++ b/BleemSync.Services/GameService.cs
@@ -22,37 +22,37 @@ namespace BleemSync.Services
             _configuration = configuration;
         }
 
-        public GameInfo GetGameInfo(int gameId)
+        public GameInfo GetGameInfo(String gamePath)
         {
             GameInfo game;
 
             try
             {
-                game = GetGameInfoFromFile(gameId);
+                game = GetGameInfoFromFile(gamePath);
             }
             catch (Exception e) {
                 Console.WriteLine("Game.ini doesn't exist, grabbing from BleemSync Central");
 
-                game = GetGameInfoFromCentral(gameId);
+                game = GetGameInfoFromCentral(gamePath);
             }
 
             return game;
         }
 
-        public GameInfo GetGameInfoFromFile(int gameId)
+        public GameInfo GetGameInfoFromFile(String gamePath)
         {
             var gamesDirectory = Filesystem.GetGamesDirectory(_configuration["GamesPath"]);
 
             Configuration config = null;
 
-            var path = Path.Combine(new [] { gamesDirectory, gameId.ToString(), "GameData", "Game.ini"});
+            var path = Path.Combine(new [] { gamesDirectory, gamePath, "Game.ini"});
             config = Configuration.LoadFromFile(path);
 
             var section = config["Game"];
 
             var game = new GameInfo()
             {
-                Id = gameId,
+                RelativePath = gamePath,
                 Title = section["Title"].StringValue,
                 Publisher = section["Publisher"].StringValue,
                 Year = section["Year"].IntValue,
@@ -73,14 +73,14 @@ namespace BleemSync.Services
             config["Game"]["Players"].StringValue = gameInfo.Players.ToString();
             config["Game"]["Discs"].StringValue = String.Join(',', gameInfo.DiscIds);
 
-            config.SaveToFile(Path.Combine(path, "GameData", "Game.ini"));
+            config.SaveToFile(Path.Combine(path, "Game.ini"));
         }
 
-        public GameInfo GetGameInfoFromCentral(int gameId)
+        public GameInfo GetGameInfoFromCentral(String gamePath)
         {
             var gamesDirectory = Filesystem.GetGamesDirectory(_configuration["GamesPath"]);
 
-            var files = Directory.GetFiles(Path.Combine(gamesDirectory, gameId.ToString(), "GameData"));
+            var files = Directory.GetFiles(Path.Combine(gamesDirectory, gamePath));
             var discMap = new Dictionary<string, string>();
             var gameInfo = new GameInfo();
 
@@ -92,8 +92,8 @@ namespace BleemSync.Services
                 {
                     try
                     {
-                        var serial = DiscImage.GetSerialNumber(Path.Combine(gamesDirectory, gameId.ToString(), file));
-                        
+                        var serial = DiscImage.GetSerialNumber(Path.Combine(gamesDirectory, gamePath, file));
+
                         discMap.Add(serial, fileInfo.Name.Replace(fileInfo.Extension, ""));
 
                         Console.WriteLine($"Found serial {serial} from disc image file {file}");
@@ -112,6 +112,7 @@ namespace BleemSync.Services
 
                 var game = JsonConvert.DeserializeObject<GameDTO>(result.Content);
 
+		            gameInfo.RelativePath = gamePath;
                 gameInfo.Title = game.Title;
                 gameInfo.Year = game.DateReleased.Year;
                 gameInfo.Publisher = game.Publisher;
@@ -122,12 +123,12 @@ namespace BleemSync.Services
                     gameInfo.DiscIds.Add(discMap[serial]);
                 }
 
-                WriteGameInfoToFile(gameInfo, Path.Combine(gamesDirectory, gameId.ToString()));
+                WriteGameInfoToFile(gameInfo, Path.Combine(gamesDirectory, gamePath));
 
                 var coverFileName = gameInfo.DiscIds.First() + ".png";
 
                 // Download the cover
-                if (!File.Exists(Path.Combine(gamesDirectory, gameId.ToString(), "GameData", coverFileName)))
+                if (!File.Exists(Path.Combine(gamesDirectory, gamePath, coverFileName)))
                 {
                     try
                     {
@@ -135,7 +136,7 @@ namespace BleemSync.Services
                         {
                             wc.DownloadFile(
                                 new Uri(_configuration["BleemSyncCentralUrl"] + "/api/PlayStation/GetCoverBySerial/" + discMap.Keys.First()),
-                                Path.Combine(gamesDirectory, gameId.ToString(), "GameData", coverFileName)
+                                Path.Combine(gamesDirectory, gamePath, coverFileName)
                             );
                         }
                     }

--- a/BleemSync.Services/ViewModels/GameDTO.cs
+++ b/BleemSync.Services/ViewModels/GameDTO.cs
@@ -8,6 +8,7 @@ namespace BleemSync.Central.ViewModels
     public class GameDTO
     {
         public int Id { get; set; }
+	      public String RelativePath { get; set; }
         public string Title { get; set; }
         public string CommonTitle { get; set; }
         public string Region { get; set; }

--- a/BleemSync.Utilities/BleemSync.Utilities.csproj
+++ b/BleemSync.Utilities/BleemSync.Utilities.csproj
@@ -14,4 +14,9 @@
     </Reference>
   </ItemGroup>
 
+  <ItemGroup>
+    <RuntimeHostConfigurationOption Include="System.Globalization.Invariant" Value="true" />
+  </ItemGroup>
+
+
 </Project>

--- a/BleemSync.Utilities/Filesystem.cs
+++ b/BleemSync.Utilities/Filesystem.cs
@@ -43,6 +43,30 @@ namespace BleemSync.Utilities
             return gameIds;
         }
 
+        public static List<String> GetGamePaths(string gamesDir = "")
+        {
+            gamesDir = GetGamesDirectory(gamesDir);
+
+            var dirList = Directory.GetDirectories(gamesDir).Select(path => new DirectoryInfo(path).Name);
+
+            var gamePaths = dirList.Select(directoryName =>
+            {
+                if (int.TryParse(directoryName, out var gameId))
+                {
+                    return Path.Join(directoryName, "GameData");
+                }
+                else
+                {
+                    return directoryName;
+                }
+
+            }).ToList();
+
+            gamePaths.Sort();
+
+        	  return gamePaths;
+        }
+
         public static string GetGamesDirectory(string gamesDir = "")
         {
             var currentPath = GetExecutingDirectory();

--- a/BleemSync/BleemSync.csproj
+++ b/BleemSync/BleemSync.csproj
@@ -26,4 +26,8 @@
     <ProjectReference Include="..\BleemSync.Utilities\BleemSync.Utilities.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <RuntimeHostConfigurationOption Include="System.Globalization.Invariant" Value="true" />
+  </ItemGroup>
+
 </Project>

--- a/BleemSync/Program.cs
+++ b/BleemSync/Program.cs
@@ -43,9 +43,9 @@ namespace BleemSync
         {
             try
             {
-                var gameService = new GameService(configuration);
+		            var gameService = new GameService(configuration);
 
-                var gameIds = Filesystem.GetGameIds(configuration["GamesPath"]);
+                var gamePaths = Filesystem.GetGamePaths(configuration["GamesPath"]);
 
 
                 foreach (var existingGame in db.Games)
@@ -62,12 +62,16 @@ namespace BleemSync
 
                 var infos = new List<GameInfo>();
 
-                foreach (var id in gameIds)
+		            var idx_count = 1;
+                foreach (var path in gamePaths)
                 {
                     try
                     {
-                        infos.Add(gameService.GetGameInfo(id));
+                        GameInfo info = gameService.GetGameInfo(path);
+	                      info.Id = idx_count;
+	                      infos.Add(info);
                         Console.WriteLine("");
+			                  idx_count++;;
                     }
                     catch
                     {
@@ -102,7 +106,7 @@ namespace BleemSync
                     Console.WriteLine(e.InnerException);
                 }
 
-                Console.WriteLine($"Successfully inserted {gameIds.Count} games");
+                Console.WriteLine($"Successfully inserted {gamePaths.Count} games");
             }
             catch (Exception e)
             {

--- a/Payload/bleemsync/etc/bleemsync/FUNC/0050_bleemsync.funcs
+++ b/Payload/bleemsync/etc/bleemsync/FUNC/0050_bleemsync.funcs
@@ -44,7 +44,7 @@ launch_BootMenu(){
   else
     $bleemsync_path/bin/boot_menu --image-folder "$images_path"
   fi
-  
+
   command=""
   [ -f "/tmp/launchfilecommand" ] && command=$(cat "/tmp/launchfilecommand") && rm -f "/tmp/launchfilecommand"
   if [ "$command" = "retroarch" ]; then
@@ -69,7 +69,7 @@ launch_StockUI(){
     cp "$bleemsync_path/etc/bleemsync/SUP/scripts/intercept" "/tmp/intercept"
     chmod +x "/tmp/intercept"
   fi
-  
+
   /usr/sony/bin/ui_menu --power-off-enable &> "$runtime_log_path/ui_menu.log"
 }
 ###############################################################################
@@ -126,13 +126,13 @@ execute_bleemsync_func(){
 
   # Unmount partitons and create tmpfs - Shut system down on failure
   MOUNT_FAIL=0
-  umount /data || MOUNT_FAIL=1 
-  umount /gaadata || MOUNT_FAIL=1 
+  umount /data || MOUNT_FAIL=1
+  umount /gaadata || MOUNT_FAIL=1
   # Create gaadata and data folders in tmp then mount over original folders
   mkdir -p "/var/volatile/gaadatatmp" "/var/volatile/datatmp"
-  mount -o bind "/var/volatile/gaadatatmp" "/gaadata" || MOUNT_FAIL=1 
-  mount -o bind "/var/volatile/datatmp" "/data" || MOUNT_FAIL=1 
-  mount -o bind "$bleemsync_path/etc/bleemsync/SUP/scripts/20-joystick.rules" "/etc/udev/rules.d/20-joystick.rules" || MOUNT_FAIL=1 
+  mount -o bind "/var/volatile/gaadatatmp" "/gaadata" || MOUNT_FAIL=1
+  mount -o bind "/var/volatile/datatmp" "/data" || MOUNT_FAIL=1
+  mount -o bind "$bleemsync_path/etc/bleemsync/SUP/scripts/20-joystick.rules" "/etc/udev/rules.d/20-joystick.rules" || MOUNT_FAIL=1
   mount -o bind "$bleemsync_path/etc/bleemsync/SUP/binaries/pcsx" "/usr/sony/bin/pcsx" || MOUNT_FAIL=1
 
   if [ "$MOUNT_FAIL" = "1" ]; then
@@ -161,8 +161,18 @@ execute_bleemsync_func(){
   ln -s "$mountpoint/system/region" "/var/volatile/gaadatatmp/geninfo"
   ln -s "$mountpoint/system/bios" "/var/volatile/gaadatatmp/system/bios"
   ln -s "$mountpoint/system/preferences/system" "/var/volatile/gaadatatmp/preferences"
-  ls "$mountpoint/games" | grep '^[0-9]\+$' | xargs -I % sh -c "ln -s $mountpoint/games/%/GameData /var/volatile/gaadatatmp/%"
-  
+
+  i=1
+  for game in $mountpoint/games/*
+  do
+    if [ -d "${game}" ]; then
+      game_dir="${game}"
+      [ -d "${game_dir}/GameData" ] && game_dir="${game}/GameData"
+      ln -s "${game_dir}" /var/volatile/gaadatatmp/$i
+      i=$((i+1))
+    fi
+  done
+
   # Create data on tmpfs
   mkdir -p "/var/volatile/datatmp/sony/sgmo" "/var/volatile/datatmp/AppData/sony"
   # ln -s "/tmp/diag" "/tmp/datatmp/sony/sgmo/diag"
@@ -171,7 +181,19 @@ execute_bleemsync_func(){
   ln -s "$mountpoint/system/preferences/user" "/var/volatile/datatmp/AppData/sony/ui"
   ln -s "$mountpoint/system/preferences/autodimmer" "/var/volatile/datatmp/AppData/sony/auto_dimmer"
   cp -fr "/usr/sony/share/recovery/AppData/sony/pcsx" "/var/volatile/datatmp/AppData/sony/pcsx"
-  ls "$mountpoint/games" | grep '^[0-9]\+$' | xargs -I % sh -c "rm -rf /var/volatile/datatmp/AppData/sony/pcsx/% && ln -s $mountpoint/games/% /var/volatile/datatmp/AppData/sony/pcsx/%"
+
+  i=1
+  for game in $mountpoint/games/*
+  do
+    if [ -d "${game}" ]; then
+      game_dir="${game}"
+      [ -d "${game_dir}/GameData" ] && game_dir="${game}/GameData"
+      rm -rf /var/volatile/datatmp/AppData/sony/pcsx/$i
+      ln -s "${game_dir}" /var/volatile/datatmp/AppData/sony/pcsx/$i
+      i=$((i+1))
+    fi
+  done
+
   ln -s "$mountpoint/system/bios" "/var/volatile/datatmp/AppData/sony/pcsx/bios"
   ln -s "/usr/sony/bin/plugins" "/var/volatile/datatmp/AppData/sony/pcsx/plugins"
 
@@ -206,7 +228,7 @@ execute_bleemsync_func(){
     echo "COMMIT;" >> "/tmp/join.sql"
 
     sed -i -e 's/;,/;/g' "/tmp/join.sql" #Required cleanup because of potential dirty characters in SONY stock SQLite DB
-    
+
     $bleemsync_path/bin/sqlite3 "/var/volatile/gaadatatmp/databases/regional.db" -cmd ".read /tmp/join.sql" ".quit"
 
     if [ "$link_alphabeticalise" = "1" ]; then
@@ -233,16 +255,16 @@ execute_bleemsync_func(){
   udevadm trigger
 
   # Default pcsx.cfg
-  cd "$mountpoint/games"
-  for D in *; do
-    if [ -d "$D" ]; then
-      if [ ! -f "$D/.pcsx/pcsx.cfg" ]; then
-        mkdir -p "$D/.pcsx"
-        cp -f "$mountpoint/system/defaults/pcsx.cfg" "$D/.pcsx/pcsx.cfg"
-      fi
+  for game in $mountpoint/games/*
+  do
+    if [ -d "${game}" ]; then
+      game_dir="${game}"
+      [ -d "${game_dir}/GameData" ] && game_dir="${game}/GameData"
+      [ ! -f "${game_dir}/.pcsx/pcsx.cfg" ] && mkdir -p "${game_dir}/.pcsx" && cp -f "$mountpoint/system/defaults/pcsx.cfg" "${game_dir}/.pcsx/pcsx.cfg"
     fi
   done
-  cd "/home/root" 
+
+  cd "/home/root"
 
   end=$(date +%s%N)
   echo "[BLEEMSYNC](PROFILE) BleemSync general fixing took: $(((end-start)/1000000))ms to execute"
@@ -283,10 +305,10 @@ execute_bleemsync_func(){
 #-----------------------------------------------------------------------------#
   start=$(date +%s%N)
   #Cleanup before starting main user applications
-  rm -rf "/tmp/systemd"*  
+  rm -rf "/tmp/systemd"*
   rm -rf "/tmp/diag"
   rm -rf "/tmp/"*".sql"
-  
+
   killall -s KILL sdl_display &> /dev/null
   booted=0
 
@@ -303,7 +325,7 @@ execute_bleemsync_func(){
   if [ "$(who | wc -l)" = "1" ]; then
     while true; do
       sleep 9999
-    done    
+    done
   else
     rm -rf "/tmp/ra_cache"
     sync

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ BleemSync is a relatively safe way to add games to your PlayStation Classic.
 ## Automatic Game Configuration
 BleemSync has the ability to download game info from BleemSync Central, an online database. To utilize automatic metadata scraping, make sure your folder structure looks something like this:
 ```
-Games/
+games/
     1/
         GameData/
             Cool Boarders.bin
@@ -24,11 +24,12 @@ Games/
     2/
         GameData/
             Cool Boarders 2.bin
-            Cool Boarders 2.cue
-    3/
-        ...
+            Cool Boarders 2.cue            
+    Need For Speed III/
+        Need For Speed III.cue
+        Need For Speed III.bin
 ```
-On the root of your flash drive, create a `Games` folder. In this folder, create a folder for each game you would like to add to the system. The folders must be numbered sequentially.
+On the root of your flash drive, create a `games` folder. In this folder, create a folder for each game you would like to add to the system.
 
 Please note that it is not mandatory to have your `bin`/`cue` files named something specific. However, your `cue` file must reference your `bin` file exactly. The name of these files has no effect on the automatic metadata scraping. BleemSync will find the serial number embedded in the disc image and run it against the database.
 
@@ -41,11 +42,35 @@ From here, you can skip the "Manual Game Configuration" step and move onto "Sync
 **Also also please note that automatic metadata scraping will not run on boot of the system as it has no internet connectivity. Please run on a desktop/laptop to use this feature.**
 
 ## Manual Game Configuration
-On the root of your flash drive, create a `Games` folder. In this folder, create a folder for each game you would like to add to the system. The folders must be numbered sequentially. Each game folder must contain a `GameData` folder which contains a `Game.ini`, cover art image, `pcsx.cfg`, and the game's `bin` and `cue` files. A template of the `Games` folder can be found in the release ZIP.
+On the root of your flash drive, create a `games` folder. In this folder, create a folder for each game you would like to add to the system. Each game folder must contain a `Game.ini`, cover art image, `pcsx.cfg`, and the game's `bin` and `cue` files. A template of the `games` folder can be found in the release ZIP.
 
 A proper folder structure looks something like this:
 ```
-Games/
+games/
+    Final Fantasy VII/
+        Game.ini
+        pcsx.cfg
+        Final Fantasy VII CD1.cue
+        Final Fantasy VII CD1.bin
+        Final Fantasy VII CD2.cue
+        Final Fantasy VII CD2.bin
+        Final Fantasy VII CD3.cue
+        Final Fantasy VII CD3.bin
+    Need For Speed III/
+        Game.ini
+        pcsx.cfg
+        Need For Speed III.cue
+        Need For Speed III.bin
+    Crash Bandicoot/
+        ...
+
+```
+
+Please note:
+
+You can also use the old folder structure from Bleemsync < 0.7 . Be aware that this will be deprecated soon!
+```
+games/
     1/
         GameData/
             Game.ini

--- a/package-build.sh
+++ b/package-build.sh
@@ -1,0 +1,34 @@
+version="0.3.2"
+
+# Must run the following as admin if you want to build and compress
+# Install-Module 7Zip4PowerShell -Force -Verbose
+
+rm -rf BleemSync.Payload/System/BleemSync
+mkdir -p BleemSync.Payload/System/BleemSync
+
+dotnet publish -c release -r linux-arm
+cp -R BleemSync/bin/Release/netcoreapp2.1/linux-arm/publish/* ./BleemSync.Payload/System/BleemSync
+
+dotnet publish -c release -r linux-x64
+rm -rf ./Publish
+mkdir -p ./Publish/BleemSync
+cp ./BleemSync/bin/Release/netcoreapp2.1/linux-x64/publish/* ./Publish/BleemSync
+cp -R ./BleemSync.Payload/* ./Publish
+7za a BleemSync-$version-linux-x64.zip Publish/*
+# Compress-7Zip "Publish/*" -Verbose -ArchiveFileName BleemSync-$version-linux-x64.zip -Format Zip
+
+dotnet publish -c release -r osx-x64
+rm -rf ./Publish
+mkdir -p Publish/BleemSync
+cp ./BleemSync/bin/Release/netcoreapp2.1/osx-x64/publish/* ./Publish/BleemSync
+cp -R ./BleemSync.Payload/* ./Publish
+7za a BleemSync-$version-osx-x64.zip Publish/*
+# Compress-7Zip "Publish" -ArchiveFileName BleemSync-$version-osx-x64.zip -Format Zip
+
+dotnet publish -c release -r win7-x86
+rm -rf ./Publish
+mkdir -p Publish/BleemSync
+cp ./BleemSync/bin/Release/netcoreapp2.1/win7-x86/publish/* ./Publish/BleemSync
+cp -R ./BleemSync.Payload/* ./Publish
+7za a BleemSync-$version-win7-x86.zip Publish/*
+# Compress-7Zip "Publish" -ArchiveFileName BleemSync-$version-win7-x86.zip -Format Zip


### PR DESCRIPTION
This PR adds the ability to use a different folder structure than

```
games/<<NUMBER>>/GameData/*.cue/bin
```

as an example one can use a game name folder within games:

```
games/Cool Boarders/*.cue/bin
```

It consists of 2 things:
- a change for BleemSync itself to not search by folder ID but uses a relative path instead
- a change in etc/bleemsync/FUNC/0050_bleemsync.funcs

Re-Build of arm linux binary is necessary for this to work!
