### PR TITLE
Add performance profiling for RetroArch functions / Add alternative format support for intercept

### DIFF
--- a/Payload/bleemsync/etc/bleemsync/FUNC/0030_retroarch.funcs
+++ b/Payload/bleemsync/etc/bleemsync/FUNC/0030_retroarch.funcs
@@ -24,6 +24,7 @@ ra_savestate_path="/tmp/ra_savestate"
 #  intercept_save_state=false # Set to true if ui_menu launches with -load
 
 launch_retroarch_from_StockUI(){
+  start=$(date +%s%N)
   echo "[BLEEMSYNC](INFO) Launching RetroArch from ui_menu"
   #  Check RA Exists and is configured correctly
   [ -f "$runtime_log_path/retroarch.log" ] && rm -f "$runtime_log_path/retroarch.log" 
@@ -54,6 +55,8 @@ launch_retroarch_from_StockUI(){
 
   #  Launch retroarch
   echo "[BLEEMSYNC](INFO) Launching RetroArch for game $intercept_game_path"
+  end=$(date +%s%N)
+  echo "[BLEEMSYNC](PROFILE) RetroArch launch from Stock UI took: $(((end-start)/1000000))ms to execute (up to launching RetroArch)"
   $retroarch_path/retroarch -v -L "$retroarch_path/.config/retroarch/cores/pcsx_rearmed_libretro.so" "$intercept_game_path" &> "$runtime_log_path/retroarch.log"
   echo "[BLEEMSYNC](INFO) RetroArch exit code $?"
   rm -fr "/tmp/ra_cache"
@@ -61,6 +64,7 @@ launch_retroarch_from_StockUI(){
 
 exit_checkSaveState(){
   # This function should only be called from the intercept script after retroarch exits
+  start=$(date +%s%N)
   echo "[BLEEMSYNC](INFO) checking for auto save state on retroarch exit"
 
   # An auto save state is created automatically, but what if the game disc was changed since
@@ -71,6 +75,8 @@ exit_checkSaveState(){
 
   if [ "$ra_last_game" == "" ]; then
     echo "[BLEEMSYNC](INFO) no auto save state exists"
+    end=$(date +%s%N)
+    echo "[BLEEMSYNC](PROFILE) RetroArch check for save state took: $(((end-start)/1000000))ms to execute"
     return 0
   fi
 
@@ -106,11 +112,14 @@ exit_checkSaveState(){
   # Remove the temporary save state folder. This is only used when Stock UI is launching RetroArch
   # and only for the current game
   rm -fR "$ra_savestate_path"
+  end=$(date +%s%N)
+  echo "[BLEEMSYNC](PROFILE) RetroArch check for save state took: $(((end-start)/1000000))ms to execute"
 }
 
 link_ra_memory_cards(){
   #  This function will link ui_menu and retroarch memory cards
   #  ui_menu memory cards take precedence
+  start=$(date +%s%N)
   echo "[BLEEMSYNC](INFO) linking ui_menu memory cards to RetroArch"
   if ls -la | grep -i ".pcsx ->"; then
     if [ ! -f "/data/AppData/sony/pcsx/.pcsx/memcards/card1.mcd" ]; then
@@ -138,6 +147,8 @@ link_ra_memory_cards(){
       fi
     done
   fi
+  end=$(date +%s%N)
+  echo "[BLEEMSYNC](PROFILE) RetroArch link memory cards took: $(((end-start)/1000000))ms to execute"
 }
 
 ###############################################################################

--- a/Payload/bleemsync/etc/bleemsync/FUNC/0030_retroarch.funcs
+++ b/Payload/bleemsync/etc/bleemsync/FUNC/0030_retroarch.funcs
@@ -56,7 +56,7 @@ launch_retroarch_from_StockUI(){
   #  Launch retroarch
   echo "[BLEEMSYNC](INFO) Launching RetroArch for game $intercept_game_path"
   end=$(date +%s%N)
-  echo "[BLEEMSYNC](PROFILE) RetroArch launch from Stock UI took: $(((end-start)/1000000))ms to execute (up to launching RetroArch)"
+  echo "[BLEEMSYNC](PROFILE) RetroArch launch_retroarch_from_StockUI function took: $(((end-start)/1000000))ms to execute (up to launching RetroArch executable)"
   $retroarch_path/retroarch -v -L "$retroarch_path/.config/retroarch/cores/pcsx_rearmed_libretro.so" "$intercept_game_path" &> "$runtime_log_path/retroarch.log"
   echo "[BLEEMSYNC](INFO) RetroArch exit code $?"
   rm -fr "/tmp/ra_cache"

--- a/Payload/bleemsync/etc/bleemsync/SUP/scripts/intercept
+++ b/Payload/bleemsync/etc/bleemsync/SUP/scripts/intercept
@@ -18,6 +18,14 @@ intercept_game_id=""
 intercept_game_ext=""
 intercept_game_alternative_path=""
 intercept_save_state=false
+intercept_file_formats=(    # alternative PCSX ReARMed game formats
+    "m3u"
+    "pbp"
+    "img"
+    "mdf"
+    "toc"
+    "cbn" 
+)
 
 ### START INTERCEPT SCRIPT ####################################################
 # This should be launched directly from ui_menu by
@@ -54,23 +62,24 @@ do
         intercept_game_ext="${arg##*.}"
         echo "[INTERCEPT](INFO) Game extension: $intercept_game_ext"
 
-        # This is the place to check if the game exists in an alternative format
+        # Check if the game exists in an alternative format
         # The game path always has .cue appened to the BASENAME field of the DISC table in regional.db
         # EXCEPT when the game is launched from a Save State. In this case the Game Path is determined from
         # the first line of filename.txt.res in the games PCSX data directory (ie. /data/AppData/sony/pcsx/1/.pcsx/filename.txt.res)
         if [ "$intercept_save_state" = false ]; then
 
-            # This is an example to check for a PBP format game
-            intercept_game_alternative_path="${arg%.cue}.pbp"
-            if [ -f "$intercept_game_alternative_path" ]; then
-
-                echo "[INTERCEPT](INFO) Alternative game format exists (PBP), this will be used instead of the .cue"
-                arg="$intercept_game_alternative_path"
-                intercept_game_path="$arg"
-                intercept_game_ext="pbp"
-                echo "[INTERCEPT](INFO) New Game full path: ${intercept_game_path}"
-                echo "[INTERCEPT](INFO) New Game extension: ${intercept_game_ext}"
-            fi
+            for f in "${intercept_file_formats[@]}"; do
+                intercept_game_alternative_path="${arg%.cue}.${f}"
+                if [ -f "$intercept_game_alternative_path" ]; then
+                    echo "[INTERCEPT](INFO) Alternative game format exists (${f}), this will be used instead of the .cue"
+                    arg="$intercept_game_alternative_path"
+                    intercept_game_path="$arg"
+                    intercept_game_ext="${f}"
+                    echo "[INTERCEPT](INFO) New Game full path: ${intercept_game_path}"
+                    echo "[INTERCEPT](INFO) New Game extension: ${intercept_game_ext}"
+                    break
+                fi
+            done
         fi
         found_cdfile=false
         continue

--- a/Payload/bleemsync/etc/bleemsync/SUP/scripts/intercept
+++ b/Payload/bleemsync/etc/bleemsync/SUP/scripts/intercept
@@ -4,6 +4,7 @@
 # ModMyClassic.com / https://discordapp.com/invite/8gygsrw
 ###############################################################################
 
+start=$(date +%s%N)
 ### LOAD CONFIGURATION ########################################################
 source "/media/bleemsync/etc/bleemsync/CFG/bleemsync.cfg"
 
@@ -47,6 +48,7 @@ found_cdfile=false
 
 # Loop through each argument to pull out information relating to which game is being loaded
 # and whether this is a Save State load
+start_arg=$(date +%s%N)
 for arg in "$@" 
 do
 
@@ -67,7 +69,8 @@ do
         # EXCEPT when the game is launched from a Save State. In this case the Game Path is determined from
         # the first line of filename.txt.res in the games PCSX data directory (ie. /data/AppData/sony/pcsx/1/.pcsx/filename.txt.res)
         if [ "$intercept_save_state" = false ]; then
-
+            
+            start_alt=$(date +%s%N)
             for f in "${intercept_file_formats[@]}"; do
                 intercept_game_alternative_path="${arg%.cue}.${f}"
                 if [ -f "$intercept_game_alternative_path" ]; then
@@ -80,6 +83,8 @@ do
                     break
                 fi
             done
+            end_alt=$(date +%s%N)
+            echo "[INTERCEPT](PROFILE) finding alternative game formats took: $(((end_alt-start_alt)/1000000))ms to execute"
         fi
         found_cdfile=false
         continue
@@ -100,12 +105,15 @@ do
     #   Build the new parameters for PCSX
     intercept_command="${intercept_command} ${arg}"
 done
-
+end_arg=$(date +%s%N)
+echo "[INTERCEPT](PROFILE) extracting arguments took: $(((end_arg-start_arg)/1000000))ms to execute"
 
 
 if [ "$launch_ra_from_stock_UI" = "1" ]; then
 
     echo "[INTERCEPT](INFO) RetroArch is enabled as the emulator"
+    end=$(date +%s%N)
+    echo "[INTERCEPT](PROFILE) up to launching RetroArch took: $(((end-start)/1000000))ms to execute"
     link_ra_memory_cards
     launch_retroarch_from_StockUI
     exit_checkSaveState
@@ -114,6 +122,8 @@ if [ "$launch_ra_from_stock_UI" = "1" ]; then
 fi
 
 echo "[INTERCEPT](INFO) Launching $intercept_pcsx_path $intercept_command -cdfile $intercept_game_path"
+end=$(date +%s%N)
+echo "[INTERCEPT](PROFILE) up to launching stock pcsx took: $(((end-start)/1000000))ms to execute"
 "$intercept_pcsx_path" $intercept_command -cdfile "$intercept_game_path"
 
 # Exit returning the pcsx exit code


### PR DESCRIPTION
* Add performance profiling for RetroArch functions and intercept script
* Add alternative game format support in intercept script (all formats supported by PCSX ReARMed). Specifically added to support .m3u which will enable more user friendly disc swaps in multi disc games for RetroArch.