### PR TITLE
Few fixes and theming script redone.

### DIFF
--- a/Payload/bleemsync/etc/bleemsync/FUNC/0040_theme.funcs
+++ b/Payload/bleemsync/etc/bleemsync/FUNC/0040_theme.funcs
@@ -1,4 +1,21 @@
 #!/bin/sh
+#
+#  Copyright 2019 ModMyClassic (https://modmyclassic.com/license)
+#  
+#  This program is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#  
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#  
+#  You should have received a copy of the GNU General Public License
+#  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+
 ###############################################################################
 # BleemSync Function Library - Stock UI Themes
 # ModMyClassic.com / https://discordapp.com/invite/8gygsrw
@@ -23,362 +40,94 @@ select_UI_theme(){
   
   # Lower-case the theme variable incase it causes and issue
   selected_theme="$(echo $selected_theme | tr 'A-Z' 'a-z')"
-
+  
+  # Initial vars
+  found_theme=0
+  found_boot_files=0
+  found_font_files=0
+  found_image_files=0
+  found_music_files=0
+  found_sound_files=0
+  
   if [ "$selected_theme" != "stock" ] && [ -d "$themes_path/$selected_theme" ]; then
-    echo "[BLEEMSYNC](INFO)(theme) theme '$selected_theme' selected"
+    # Set found theme var for log
+    found_theme=1
+    # Check for the boot folder
+    if [ -d "$themes_path/$selected_theme/boot" ]; then
+      cd "$themes_path/$selected_theme/boot"
+      for boot_file in $(find -iname \*.png -o -iname \*.wav | sed -e 's,^\./,,'); do
+        if [ ${boot_file: -4} == ".png" ]; then mount -o bind "$themes_path/$selected_theme/boot/$boot_file" "$images_path/$boot_file"; found_boot_files=1; fi
+        if [ ${boot_file: -4} == ".wav" ]; then mount -o bind "$themes_path/$selected_theme/boot/$boot_file" "$sounds_path/$boot_file"; found_boot_files=1; fi
+        # if [ ${boot_file: -4} == ".png" ]; then images_path="$themes_path/$selected_theme/boot"; found_boot_files=1; fi
+        # if [ ${boot_file: -4} == ".wav" ]; then sounds_path="$themes_path/$selected_theme/boot"; found_boot_files=1; fi
+      done
+      cd "/home/root"
+    fi 2> /dev/null 
     # Check for the font folder
     if [ -d "$themes_path/$selected_theme/font" ]; then
-      mount -o bind "$themes_path/$selected_theme/font/SST-Bold.ttf" "/usr/sony/share/data/font/SST-Bold.ttf"
-      mount -o bind "$themes_path/$selected_theme/font/SST-Medium.ttf" "/usr/sony/share/data/font/SST-Medium.ttf"
-      mount -o bind "$themes_path/$selected_theme/font/SSTJapanese-Bold.ttf" "/usr/sony/share/data/font/SSTJapanese-Bold.ttf"
-      mount -o bind "$themes_path/$selected_theme/font/SSTJapanese-Regular.ttf" "/usr/sony/share/data/font/SSTJapanese-Regular.ttf"
-      echo "[BLEEMSYNC](INFO)(theme) mounting available font files"
-    else
-      echo "[BLEEMSYNC](INFO)(theme) no font folder found"
+      cd "$themes_path/$selected_theme/font"
+      for font_file in $(find -iname \*.ttf | sed -e 's,^\./,,'); do
+        mount -o bind "$themes_path/$selected_theme/font/$font_file" "/usr/sony/share/data/font/$font_file"
+        found_font_files=1
+      done
+      cd "/home/root"
     fi 2> /dev/null 
     # Check for the images folder
     if [ -d "$themes_path/$selected_theme/images" ]; then
-      mount -o bind "$themes_path/$selected_theme/images/Game_Guide_QR.png" "/usr/sony/share/data/images/Game_Guide_QR.png"
-      mount -o bind "$themes_path/$selected_theme/images/msg_trademark_Dutch.png" "/usr/sony/share/data/images/msg_trademark_Dutch.png"
-      mount -o bind "$themes_path/$selected_theme/images/msg_trademark_E.png" "/usr/sony/share/data/images/msg_trademark_E.png"
-      mount -o bind "$themes_path/$selected_theme/images/msg_trademark_E_UK.png" "/usr/sony/share/data/images/msg_trademark_E_UK.png"
-      mount -o bind "$themes_path/$selected_theme/images/msg_trademark_French.png" "/usr/sony/share/data/images/msg_trademark_French.png"
-      mount -o bind "$themes_path/$selected_theme/images/msg_trademark_French_CA.png" "/usr/sony/share/data/images/msg_trademark_French_CA.png"
-      mount -o bind "$themes_path/$selected_theme/images/msg_trademark_German.png" "/usr/sony/share/data/images/msg_trademark_German.png"
-      mount -o bind "$themes_path/$selected_theme/images/msg_trademark_Italian.png" "/usr/sony/share/data/images/msg_trademark_Italian.png"
-      mount -o bind "$themes_path/$selected_theme/images/msg_trademark_J.png" "/usr/sony/share/data/images/msg_trademark_J.png"
-      mount -o bind "$themes_path/$selected_theme/images/msg_trademark_Portuguese.png" "/usr/sony/share/data/images/msg_trademark_Portuguese.png"
-      mount -o bind "$themes_path/$selected_theme/images/msg_trademark_Portuguese_BR.png" "/usr/sony/share/data/images/msg_trademark_Portuguese_BR.png"
-      mount -o bind "$themes_path/$selected_theme/images/msg_trademark_Russian.png" "/usr/sony/share/data/images/msg_trademark_Russian.png"
-      mount -o bind "$themes_path/$selected_theme/images/msg_trademark_Spanish.png" "/usr/sony/share/data/images/msg_trademark_Spanish.png"
-      mount -o bind "$themes_path/$selected_theme/images/msg_trademark_Spanish_LA.png" "/usr/sony/share/data/images/msg_trademark_Spanish_LA.png"
-      mount -o bind "$themes_path/$selected_theme/images/Rectangle.png" "/usr/sony/share/data/images/Rectangle.png"
-      mount -o bind "$themes_path/$selected_theme/images/BMP_Text/Delete_Text.png" "/usr/sony/share/data/images/BMP_Text/Delete_Text.png"
-      mount -o bind "$themes_path/$selected_theme/images/BMP_Text/Delete_Text_Dutch.png" "/usr/sony/share/data/images/BMP_Text/Delete_Text_Dutch.png"
-      mount -o bind "$themes_path/$selected_theme/images/BMP_Text/Delete_Text_E.png" "/usr/sony/share/data/images/BMP_Text/Delete_Text_E.png"
-      mount -o bind "$themes_path/$selected_theme/images/BMP_Text/Delete_Text_E_UK.png" "/usr/sony/share/data/images/BMP_Text/Delete_Text_E_UK.png"
-      mount -o bind "$themes_path/$selected_theme/images/BMP_Text/Delete_Text_French.png" "/usr/sony/share/data/images/BMP_Text/Delete_Text_French.png"
-      mount -o bind "$themes_path/$selected_theme/images/BMP_Text/Delete_Text_French_CA.png" "/usr/sony/share/data/images/BMP_Text/Delete_Text_French_CA.png"
-      mount -o bind "$themes_path/$selected_theme/images/BMP_Text/Delete_Text_German.png" "/usr/sony/share/data/images/BMP_Text/Delete_Text_German.png"
-      mount -o bind "$themes_path/$selected_theme/images/BMP_Text/Delete_Text_Italian.png" "/usr/sony/share/data/images/BMP_Text/Delete_Text_Italian.png"
-      mount -o bind "$themes_path/$selected_theme/images/BMP_Text/Delete_Text_Portuguese.png" "/usr/sony/share/data/images/BMP_Text/Delete_Text_Portuguese.png"
-      mount -o bind "$themes_path/$selected_theme/images/BMP_Text/Delete_Text_Portuguese_BR.png" "/usr/sony/share/data/images/BMP_Text/Delete_Text_Portuguese_BR.png"
-      mount -o bind "$themes_path/$selected_theme/images/BMP_Text/Delete_Text_Russian.png" "/usr/sony/share/data/images/BMP_Text/Delete_Text_Russian.png"
-      mount -o bind "$themes_path/$selected_theme/images/BMP_Text/Delete_Text_Spanish.png" "/usr/sony/share/data/images/BMP_Text/Delete_Text_Spanish.png"
-      mount -o bind "$themes_path/$selected_theme/images/BMP_Text/Delete_Text_Spanish_LA.png" "/usr/sony/share/data/images/BMP_Text/Delete_Text_Spanish_LA.png"
-      mount -o bind "$themes_path/$selected_theme/images/BMP_Text/Manual_Dutch.png" "/usr/sony/share/data/images/BMP_Text/Manual_Dutch.png"
-      mount -o bind "$themes_path/$selected_theme/images/BMP_Text/Manual_Dutch_S.png" "/usr/sony/share/data/images/BMP_Text/Manual_Dutch_S.png"
-      mount -o bind "$themes_path/$selected_theme/images/BMP_Text/Manual_E.png" "/usr/sony/share/data/images/BMP_Text/Manual_E.png"
-      mount -o bind "$themes_path/$selected_theme/images/BMP_Text/Manual_E_S.png" "/usr/sony/share/data/images/BMP_Text/Manual_E_S.png"
-      mount -o bind "$themes_path/$selected_theme/images/BMP_Text/Manual_E_UK.png" "/usr/sony/share/data/images/BMP_Text/Manual_E_UK.png"
-      mount -o bind "$themes_path/$selected_theme/images/BMP_Text/Manual_E_UK_S.png" "/usr/sony/share/data/images/BMP_Text/Manual_E_UK_S.png"
-      mount -o bind "$themes_path/$selected_theme/images/BMP_Text/Manual_French.png" "/usr/sony/share/data/images/BMP_Text/Manual_French.png"
-      mount -o bind "$themes_path/$selected_theme/images/BMP_Text/Manual_French_CA.png" "/usr/sony/share/data/images/BMP_Text/Manual_French_CA.png"
-      mount -o bind "$themes_path/$selected_theme/images/BMP_Text/Manual_French_CA_S.png" "/usr/sony/share/data/images/BMP_Text/Manual_French_CA_S.png"
-      mount -o bind "$themes_path/$selected_theme/images/BMP_Text/Manual_French_S.png" "/usr/sony/share/data/images/BMP_Text/Manual_French_S.png"
-      mount -o bind "$themes_path/$selected_theme/images/BMP_Text/Manual_German.png" "/usr/sony/share/data/images/BMP_Text/Manual_German.png"
-      mount -o bind "$themes_path/$selected_theme/images/BMP_Text/Manual_German_S.png" "/usr/sony/share/data/images/BMP_Text/Manual_German_S.png"
-      mount -o bind "$themes_path/$selected_theme/images/BMP_Text/Manual_Italian.png" "/usr/sony/share/data/images/BMP_Text/Manual_Italian.png"
-      mount -o bind "$themes_path/$selected_theme/images/BMP_Text/Manual_Italian_S.png" "/usr/sony/share/data/images/BMP_Text/Manual_Italian_S.png"
-      mount -o bind "$themes_path/$selected_theme/images/BMP_Text/Manual_J.png" "/usr/sony/share/data/images/BMP_Text/Manual_J.png"
-      mount -o bind "$themes_path/$selected_theme/images/BMP_Text/Manual_J_S.png" "/usr/sony/share/data/images/BMP_Text/Manual_J_S.png"
-      mount -o bind "$themes_path/$selected_theme/images/BMP_Text/Manual_Portuguese.png" "/usr/sony/share/data/images/BMP_Text/Manual_Portuguese.png"
-      mount -o bind "$themes_path/$selected_theme/images/BMP_Text/Manual_Portuguese_BR.png" "/usr/sony/share/data/images/BMP_Text/Manual_Portuguese_BR.png"
-      mount -o bind "$themes_path/$selected_theme/images/BMP_Text/Manual_Portuguese_BR_S.png" "/usr/sony/share/data/images/BMP_Text/Manual_Portuguese_BR_S.png"
-      mount -o bind "$themes_path/$selected_theme/images/BMP_Text/Manual_Portuguese_S.png" "/usr/sony/share/data/images/BMP_Text/Manual_Portuguese_S.png"
-      mount -o bind "$themes_path/$selected_theme/images/BMP_Text/Manual_Russian.png" "/usr/sony/share/data/images/BMP_Text/Manual_Russian.png"
-      mount -o bind "$themes_path/$selected_theme/images/BMP_Text/Manual_Russian_S.png" "/usr/sony/share/data/images/BMP_Text/Manual_Russian_S.png"
-      mount -o bind "$themes_path/$selected_theme/images/BMP_Text/Manual_Spanish.png" "/usr/sony/share/data/images/BMP_Text/Manual_Spanish.png"
-      mount -o bind "$themes_path/$selected_theme/images/BMP_Text/Manual_Spanish_LA.png" "/usr/sony/share/data/images/BMP_Text/Manual_Spanish_LA.png"
-      mount -o bind "$themes_path/$selected_theme/images/BMP_Text/Manual_Spanish_LA_S.png" "/usr/sony/share/data/images/BMP_Text/Manual_Spanish_LA_S.png"
-      mount -o bind "$themes_path/$selected_theme/images/BMP_Text/Manual_Spanish_S.png" "/usr/sony/share/data/images/BMP_Text/Manual_Spanish_S.png"
-      mount -o bind "$themes_path/$selected_theme/images/BMP_Text/MC_Dutch.png" "/usr/sony/share/data/images/BMP_Text/MC_Dutch.png"
-      mount -o bind "$themes_path/$selected_theme/images/BMP_Text/MC_Dutch_S.png" "/usr/sony/share/data/images/BMP_Text/MC_Dutch_S.png"
-      mount -o bind "$themes_path/$selected_theme/images/BMP_Text/MC_E.png" "/usr/sony/share/data/images/BMP_Text/MC_E.png"
-      mount -o bind "$themes_path/$selected_theme/images/BMP_Text/MC_E_S.png" "/usr/sony/share/data/images/BMP_Text/MC_E_S.png"
-      mount -o bind "$themes_path/$selected_theme/images/BMP_Text/MC_E_UK.png" "/usr/sony/share/data/images/BMP_Text/MC_E_UK.png"
-      mount -o bind "$themes_path/$selected_theme/images/BMP_Text/MC_E_UK_S.png" "/usr/sony/share/data/images/BMP_Text/MC_E_UK_S.png"
-      mount -o bind "$themes_path/$selected_theme/images/BMP_Text/MC_Franch_CA.png" "/usr/sony/share/data/images/BMP_Text/MC_Franch_CA.png"
-      mount -o bind "$themes_path/$selected_theme/images/BMP_Text/MC_French.png" "/usr/sony/share/data/images/BMP_Text/MC_French.png"
-      mount -o bind "$themes_path/$selected_theme/images/BMP_Text/MC_French_CA_S.png" "/usr/sony/share/data/images/BMP_Text/MC_French_CA_S.png"
-      mount -o bind "$themes_path/$selected_theme/images/BMP_Text/MC_French_S.png" "/usr/sony/share/data/images/BMP_Text/MC_French_S.png"
-      mount -o bind "$themes_path/$selected_theme/images/BMP_Text/MC_German.png" "/usr/sony/share/data/images/BMP_Text/MC_German.png"
-      mount -o bind "$themes_path/$selected_theme/images/BMP_Text/MC_German_S.png" "/usr/sony/share/data/images/BMP_Text/MC_German_S.png"
-      mount -o bind "$themes_path/$selected_theme/images/BMP_Text/MC_Italian.png" "/usr/sony/share/data/images/BMP_Text/MC_Italian.png"
-      mount -o bind "$themes_path/$selected_theme/images/BMP_Text/MC_Italian_S.png" "/usr/sony/share/data/images/BMP_Text/MC_Italian_S.png"
-      mount -o bind "$themes_path/$selected_theme/images/BMP_Text/MC_J.png" "/usr/sony/share/data/images/BMP_Text/MC_J.png"
-      mount -o bind "$themes_path/$selected_theme/images/BMP_Text/MC_J_S .png" "/usr/sony/share/data/images/BMP_Text/MC_J_S .png"
-      mount -o bind "$themes_path/$selected_theme/images/BMP_Text/MC_Portuguese.png" "/usr/sony/share/data/images/BMP_Text/MC_Portuguese.png"
-      mount -o bind "$themes_path/$selected_theme/images/BMP_Text/MC_Portuguese_BR.png" "/usr/sony/share/data/images/BMP_Text/MC_Portuguese_BR.png"
-      mount -o bind "$themes_path/$selected_theme/images/BMP_Text/MC_Portuguese_BR_S.png" "/usr/sony/share/data/images/BMP_Text/MC_Portuguese_BR_S.png"
-      mount -o bind "$themes_path/$selected_theme/images/BMP_Text/MC_Portuguese_S.png" "/usr/sony/share/data/images/BMP_Text/MC_Portuguese_S.png"
-      mount -o bind "$themes_path/$selected_theme/images/BMP_Text/MC_Russian.png" "/usr/sony/share/data/images/BMP_Text/MC_Russian.png"
-      mount -o bind "$themes_path/$selected_theme/images/BMP_Text/MC_Russian_S.png" "/usr/sony/share/data/images/BMP_Text/MC_Russian_S.png"
-      mount -o bind "$themes_path/$selected_theme/images/BMP_Text/MC_Spanish.png" "/usr/sony/share/data/images/BMP_Text/MC_Spanish.png"
-      mount -o bind "$themes_path/$selected_theme/images/BMP_Text/MC_Spanish_LA.png" "/usr/sony/share/data/images/BMP_Text/MC_Spanish_LA.png"
-      mount -o bind "$themes_path/$selected_theme/images/BMP_Text/MC_Spanish_LA_S.png" "/usr/sony/share/data/images/BMP_Text/MC_Spanish_LA_S.png"
-      mount -o bind "$themes_path/$selected_theme/images/BMP_Text/MC_Spanish_S.png" "/usr/sony/share/data/images/BMP_Text/MC_Spanish_S.png"
-      mount -o bind "$themes_path/$selected_theme/images/BMP_Text/No_Btn.png" "/usr/sony/share/data/images/BMP_Text/No_Btn.png"
-      mount -o bind "$themes_path/$selected_theme/images/BMP_Text/No_Btn_Dutch.png" "/usr/sony/share/data/images/BMP_Text/No_Btn_Dutch.png"
-      mount -o bind "$themes_path/$selected_theme/images/BMP_Text/No_Btn_E.png" "/usr/sony/share/data/images/BMP_Text/No_Btn_E.png"
-      mount -o bind "$themes_path/$selected_theme/images/BMP_Text/No_Btn_E_UK.png" "/usr/sony/share/data/images/BMP_Text/No_Btn_E_UK.png"
-      mount -o bind "$themes_path/$selected_theme/images/BMP_Text/No_Btn_French.png" "/usr/sony/share/data/images/BMP_Text/No_Btn_French.png"
-      mount -o bind "$themes_path/$selected_theme/images/BMP_Text/No_Btn_French_CA.png" "/usr/sony/share/data/images/BMP_Text/No_Btn_French_CA.png"
-      mount -o bind "$themes_path/$selected_theme/images/BMP_Text/No_Btn_German.png" "/usr/sony/share/data/images/BMP_Text/No_Btn_German.png"
-      mount -o bind "$themes_path/$selected_theme/images/BMP_Text/No_Btn_Italian.png" "/usr/sony/share/data/images/BMP_Text/No_Btn_Italian.png"
-      mount -o bind "$themes_path/$selected_theme/images/BMP_Text/No_Btn_Portuguese.png" "/usr/sony/share/data/images/BMP_Text/No_Btn_Portuguese.png"
-      mount -o bind "$themes_path/$selected_theme/images/BMP_Text/No_Btn_Portuguese_BR.png" "/usr/sony/share/data/images/BMP_Text/No_Btn_Portuguese_BR.png"
-      mount -o bind "$themes_path/$selected_theme/images/BMP_Text/No_Btn_Russian.png" "/usr/sony/share/data/images/BMP_Text/No_Btn_Russian.png"
-      mount -o bind "$themes_path/$selected_theme/images/BMP_Text/No_Btn_Spanish.png" "/usr/sony/share/data/images/BMP_Text/No_Btn_Spanish.png"
-      mount -o bind "$themes_path/$selected_theme/images/BMP_Text/No_Btn_Spanish_LA.png" "/usr/sony/share/data/images/BMP_Text/No_Btn_Spanish_LA.png"
-      mount -o bind "$themes_path/$selected_theme/images/BMP_Text/OK_Btn.png" "/usr/sony/share/data/images/BMP_Text/OK_Btn.png"
-      mount -o bind "$themes_path/$selected_theme/images/BMP_Text/OK_Btn_Dutch.png" "/usr/sony/share/data/images/BMP_Text/OK_Btn_Dutch.png"
-      mount -o bind "$themes_path/$selected_theme/images/BMP_Text/OK_Btn_E.png" "/usr/sony/share/data/images/BMP_Text/OK_Btn_E.png"
-      mount -o bind "$themes_path/$selected_theme/images/BMP_Text/OK_Btn_E_UK.png" "/usr/sony/share/data/images/BMP_Text/OK_Btn_E_UK.png"
-      mount -o bind "$themes_path/$selected_theme/images/BMP_Text/OK_Btn_French.png" "/usr/sony/share/data/images/BMP_Text/OK_Btn_French.png"
-      mount -o bind "$themes_path/$selected_theme/images/BMP_Text/OK_Btn_French_CA.png" "/usr/sony/share/data/images/BMP_Text/OK_Btn_French_CA.png"
-      mount -o bind "$themes_path/$selected_theme/images/BMP_Text/OK_Btn_German.png" "/usr/sony/share/data/images/BMP_Text/OK_Btn_German.png"
-      mount -o bind "$themes_path/$selected_theme/images/BMP_Text/OK_Btn_Italian.png" "/usr/sony/share/data/images/BMP_Text/OK_Btn_Italian.png"
-      mount -o bind "$themes_path/$selected_theme/images/BMP_Text/OK_Btn_Portuguese.png" "/usr/sony/share/data/images/BMP_Text/OK_Btn_Portuguese.png"
-      mount -o bind "$themes_path/$selected_theme/images/BMP_Text/OK_Btn_Portuguese_BR.png" "/usr/sony/share/data/images/BMP_Text/OK_Btn_Portuguese_BR.png"
-      mount -o bind "$themes_path/$selected_theme/images/BMP_Text/OK_Btn_Russian.png" "/usr/sony/share/data/images/BMP_Text/OK_Btn_Russian.png"
-      mount -o bind "$themes_path/$selected_theme/images/BMP_Text/OK_Btn_Spanish.png" "/usr/sony/share/data/images/BMP_Text/OK_Btn_Spanish.png"
-      mount -o bind "$themes_path/$selected_theme/images/BMP_Text/OK_Btn_Spanish_LA.png" "/usr/sony/share/data/images/BMP_Text/OK_Btn_Spanish_LA.png"
-      mount -o bind "$themes_path/$selected_theme/images/BMP_Text/Play_Text.png" "/usr/sony/share/data/images/BMP_Text/Play_Text.png"
-      mount -o bind "$themes_path/$selected_theme/images/BMP_Text/Play_Text_Dutch.png" "/usr/sony/share/data/images/BMP_Text/Play_Text_Dutch.png"
-      mount -o bind "$themes_path/$selected_theme/images/BMP_Text/Play_Text_E.png" "/usr/sony/share/data/images/BMP_Text/Play_Text_E.png"
-      mount -o bind "$themes_path/$selected_theme/images/BMP_Text/Play_Text_E_UK.png" "/usr/sony/share/data/images/BMP_Text/Play_Text_E_UK.png"
-      mount -o bind "$themes_path/$selected_theme/images/BMP_Text/Play_Text_French.png" "/usr/sony/share/data/images/BMP_Text/Play_Text_French.png"
-      mount -o bind "$themes_path/$selected_theme/images/BMP_Text/Play_Text_French_CA.png" "/usr/sony/share/data/images/BMP_Text/Play_Text_French_CA.png"
-      mount -o bind "$themes_path/$selected_theme/images/BMP_Text/Play_Text_German.png" "/usr/sony/share/data/images/BMP_Text/Play_Text_German.png"
-      mount -o bind "$themes_path/$selected_theme/images/BMP_Text/Play_Text_Italian.png" "/usr/sony/share/data/images/BMP_Text/Play_Text_Italian.png"
-      mount -o bind "$themes_path/$selected_theme/images/BMP_Text/Play_Text_Portuguese.png" "/usr/sony/share/data/images/BMP_Text/Play_Text_Portuguese.png"
-      mount -o bind "$themes_path/$selected_theme/images/BMP_Text/Play_Text_Portuguese_BR.png" "/usr/sony/share/data/images/BMP_Text/Play_Text_Portuguese_BR.png"
-      mount -o bind "$themes_path/$selected_theme/images/BMP_Text/Play_Text_Rossian.png" "/usr/sony/share/data/images/BMP_Text/Play_Text_Rossian.png"
-      mount -o bind "$themes_path/$selected_theme/images/BMP_Text/Play_Text_Spanish.png" "/usr/sony/share/data/images/BMP_Text/Play_Text_Spanish.png"
-      mount -o bind "$themes_path/$selected_theme/images/BMP_Text/Play_Text_Spanish_LA.png" "/usr/sony/share/data/images/BMP_Text/Play_Text_Spanish_LA.png"
-      mount -o bind "$themes_path/$selected_theme/images/BMP_Text/ResumeSave_Dutch_S.png" "/usr/sony/share/data/images/BMP_Text/ResumeSave_Dutch_S.png"
-      mount -o bind "$themes_path/$selected_theme/images/BMP_Text/ResumeSave_E_S.png" "/usr/sony/share/data/images/BMP_Text/ResumeSave_E_S.png"
-      mount -o bind "$themes_path/$selected_theme/images/BMP_Text/ResumeSave_E_UK_S.png" "/usr/sony/share/data/images/BMP_Text/ResumeSave_E_UK_S.png"
-      mount -o bind "$themes_path/$selected_theme/images/BMP_Text/ResumeSave_French_CA_S.png" "/usr/sony/share/data/images/BMP_Text/ResumeSave_French_CA_S.png"
-      mount -o bind "$themes_path/$selected_theme/images/BMP_Text/ResumeSave_French_S.png" "/usr/sony/share/data/images/BMP_Text/ResumeSave_French_S.png"
-      mount -o bind "$themes_path/$selected_theme/images/BMP_Text/ResumeSave_German_S.png" "/usr/sony/share/data/images/BMP_Text/ResumeSave_German_S.png"
-      mount -o bind "$themes_path/$selected_theme/images/BMP_Text/ResumeSave_Italian_S.png" "/usr/sony/share/data/images/BMP_Text/ResumeSave_Italian_S.png"
-      mount -o bind "$themes_path/$selected_theme/images/BMP_Text/ResumeSave_J_S.png" "/usr/sony/share/data/images/BMP_Text/ResumeSave_J_S.png"
-      mount -o bind "$themes_path/$selected_theme/images/BMP_Text/ResumeSave_Portuguese_BR_S.png" "/usr/sony/share/data/images/BMP_Text/ResumeSave_Portuguese_BR_S.png"
-      mount -o bind "$themes_path/$selected_theme/images/BMP_Text/ResumeSave_Portuguese_S.png" "/usr/sony/share/data/images/BMP_Text/ResumeSave_Portuguese_S.png"
-      mount -o bind "$themes_path/$selected_theme/images/BMP_Text/ResumeSave_Russian_S.png" "/usr/sony/share/data/images/BMP_Text/ResumeSave_Russian_S.png"
-      mount -o bind "$themes_path/$selected_theme/images/BMP_Text/ResumeSave_Spanish_LA_S.png" "/usr/sony/share/data/images/BMP_Text/ResumeSave_Spanish_LA_S.png"
-      mount -o bind "$themes_path/$selected_theme/images/BMP_Text/ResumeSave_Spanish_S.png" "/usr/sony/share/data/images/BMP_Text/ResumeSave_Spanish_S.png"
-      mount -o bind "$themes_path/$selected_theme/images/BMP_Text/Setting_Dutch.png" "/usr/sony/share/data/images/BMP_Text/Setting_Dutch.png"
-      mount -o bind "$themes_path/$selected_theme/images/BMP_Text/Setting_Dutch_S.png" "/usr/sony/share/data/images/BMP_Text/Setting_Dutch_S.png"
-      mount -o bind "$themes_path/$selected_theme/images/BMP_Text/Setting_E.png" "/usr/sony/share/data/images/BMP_Text/Setting_E.png"
-      mount -o bind "$themes_path/$selected_theme/images/BMP_Text/Setting_E_S.png" "/usr/sony/share/data/images/BMP_Text/Setting_E_S.png"
-      mount -o bind "$themes_path/$selected_theme/images/BMP_Text/Setting_E_UK.png" "/usr/sony/share/data/images/BMP_Text/Setting_E_UK.png"
-      mount -o bind "$themes_path/$selected_theme/images/BMP_Text/Setting_E_UK_S.png" "/usr/sony/share/data/images/BMP_Text/Setting_E_UK_S.png"
-      mount -o bind "$themes_path/$selected_theme/images/BMP_Text/Setting_French.png" "/usr/sony/share/data/images/BMP_Text/Setting_French.png"
-      mount -o bind "$themes_path/$selected_theme/images/BMP_Text/Setting_French_CA.png" "/usr/sony/share/data/images/BMP_Text/Setting_French_CA.png"
-      mount -o bind "$themes_path/$selected_theme/images/BMP_Text/Setting_French_CA_S.png" "/usr/sony/share/data/images/BMP_Text/Setting_French_CA_S.png"
-      mount -o bind "$themes_path/$selected_theme/images/BMP_Text/Setting_French_S.png" "/usr/sony/share/data/images/BMP_Text/Setting_French_S.png"
-      mount -o bind "$themes_path/$selected_theme/images/BMP_Text/Setting_German.png" "/usr/sony/share/data/images/BMP_Text/Setting_German.png"
-      mount -o bind "$themes_path/$selected_theme/images/BMP_Text/Setting_German_S.png" "/usr/sony/share/data/images/BMP_Text/Setting_German_S.png"
-      mount -o bind "$themes_path/$selected_theme/images/BMP_Text/Setting_Italian.png" "/usr/sony/share/data/images/BMP_Text/Setting_Italian.png"
-      mount -o bind "$themes_path/$selected_theme/images/BMP_Text/Setting_Italian_S.png" "/usr/sony/share/data/images/BMP_Text/Setting_Italian_S.png"
-      mount -o bind "$themes_path/$selected_theme/images/BMP_Text/Setting_J.png" "/usr/sony/share/data/images/BMP_Text/Setting_J.png"
-      mount -o bind "$themes_path/$selected_theme/images/BMP_Text/Setting_J_S.png" "/usr/sony/share/data/images/BMP_Text/Setting_J_S.png"
-      mount -o bind "$themes_path/$selected_theme/images/BMP_Text/Setting_Portuguese.png" "/usr/sony/share/data/images/BMP_Text/Setting_Portuguese.png"
-      mount -o bind "$themes_path/$selected_theme/images/BMP_Text/Setting_Portuguese_BR.png" "/usr/sony/share/data/images/BMP_Text/Setting_Portuguese_BR.png"
-      mount -o bind "$themes_path/$selected_theme/images/BMP_Text/Setting_Portuguese_BR_S.png" "/usr/sony/share/data/images/BMP_Text/Setting_Portuguese_BR_S.png"
-      mount -o bind "$themes_path/$selected_theme/images/BMP_Text/Setting_Portuguese_S.png" "/usr/sony/share/data/images/BMP_Text/Setting_Portuguese_S.png"
-      mount -o bind "$themes_path/$selected_theme/images/BMP_Text/Setting_Russian.png" "/usr/sony/share/data/images/BMP_Text/Setting_Russian.png"
-      mount -o bind "$themes_path/$selected_theme/images/BMP_Text/Setting_Russian_S.png" "/usr/sony/share/data/images/BMP_Text/Setting_Russian_S.png"
-      mount -o bind "$themes_path/$selected_theme/images/BMP_Text/Setting_Spanish.png" "/usr/sony/share/data/images/BMP_Text/Setting_Spanish.png"
-      mount -o bind "$themes_path/$selected_theme/images/BMP_Text/Setting_Spanish_LA.png" "/usr/sony/share/data/images/BMP_Text/Setting_Spanish_LA.png"
-      mount -o bind "$themes_path/$selected_theme/images/BMP_Text/Setting_Spanish_LA_S.png" "/usr/sony/share/data/images/BMP_Text/Setting_Spanish_LA_S.png"
-      mount -o bind "$themes_path/$selected_theme/images/BMP_Text/Setting_Spanish_S.png" "/usr/sony/share/data/images/BMP_Text/Setting_Spanish_S.png"
-      mount -o bind "$themes_path/$selected_theme/images/BMP_Text/Yes_Btn.png" "/usr/sony/share/data/images/BMP_Text/Yes_Btn.png"
-      mount -o bind "$themes_path/$selected_theme/images/BMP_Text/Yes_Btn_Dutch.png" "/usr/sony/share/data/images/BMP_Text/Yes_Btn_Dutch.png"
-      mount -o bind "$themes_path/$selected_theme/images/BMP_Text/Yes_Btn_E.png" "/usr/sony/share/data/images/BMP_Text/Yes_Btn_E.png"
-      mount -o bind "$themes_path/$selected_theme/images/BMP_Text/Yes_Btn_E_UK.png" "/usr/sony/share/data/images/BMP_Text/Yes_Btn_E_UK.png"
-      mount -o bind "$themes_path/$selected_theme/images/BMP_Text/Yes_Btn_French.png" "/usr/sony/share/data/images/BMP_Text/Yes_Btn_French.png"
-      mount -o bind "$themes_path/$selected_theme/images/BMP_Text/Yes_Btn_French_CA.png" "/usr/sony/share/data/images/BMP_Text/Yes_Btn_French_CA.png"
-      mount -o bind "$themes_path/$selected_theme/images/BMP_Text/Yes_Btn_German.png" "/usr/sony/share/data/images/BMP_Text/Yes_Btn_German.png"
-      mount -o bind "$themes_path/$selected_theme/images/BMP_Text/Yes_Btn_Italian.png" "/usr/sony/share/data/images/BMP_Text/Yes_Btn_Italian.png"
-      mount -o bind "$themes_path/$selected_theme/images/BMP_Text/Yes_Btn_Portuguese.png" "/usr/sony/share/data/images/BMP_Text/Yes_Btn_Portuguese.png"
-      mount -o bind "$themes_path/$selected_theme/images/BMP_Text/Yes_Btn_Portuguese_BR.png" "/usr/sony/share/data/images/BMP_Text/Yes_Btn_Portuguese_BR.png"
-      mount -o bind "$themes_path/$selected_theme/images/BMP_Text/Yes_Btn_Russian.png" "/usr/sony/share/data/images/BMP_Text/Yes_Btn_Russian.png"
-      mount -o bind "$themes_path/$selected_theme/images/BMP_Text/Yes_Btn_Spanish.png" "/usr/sony/share/data/images/BMP_Text/Yes_Btn_Spanish.png"
-      mount -o bind "$themes_path/$selected_theme/images/BMP_Text/Yes_Btn_Spanish_LA.png" "/usr/sony/share/data/images/BMP_Text/Yes_Btn_Spanish_LA.png"
-      mount -o bind "$themes_path/$selected_theme/images/BMP_TXT_SST/msg_cant_change_discs_now_Dutch.png" "/usr/sony/share/data/images/BMP_TXT_SST/msg_cant_change_discs_now_Dutch.png"
-      mount -o bind "$themes_path/$selected_theme/images/BMP_TXT_SST/msg_cant_change_discs_now_E.png" "/usr/sony/share/data/images/BMP_TXT_SST/msg_cant_change_discs_now_E.png"
-      mount -o bind "$themes_path/$selected_theme/images/BMP_TXT_SST/msg_cant_change_discs_now_E_UK.png" "/usr/sony/share/data/images/BMP_TXT_SST/msg_cant_change_discs_now_E_UK.png"
-      mount -o bind "$themes_path/$selected_theme/images/BMP_TXT_SST/msg_cant_change_discs_now_French.png" "/usr/sony/share/data/images/BMP_TXT_SST/msg_cant_change_discs_now_French.png"
-      mount -o bind "$themes_path/$selected_theme/images/BMP_TXT_SST/msg_cant_change_discs_now_French_CA.png" "/usr/sony/share/data/images/BMP_TXT_SST/msg_cant_change_discs_now_French_CA.png"
-      mount -o bind "$themes_path/$selected_theme/images/BMP_TXT_SST/msg_cant_change_discs_now_German.png" "/usr/sony/share/data/images/BMP_TXT_SST/msg_cant_change_discs_now_German.png"
-      mount -o bind "$themes_path/$selected_theme/images/BMP_TXT_SST/msg_cant_change_discs_now_Italian.png" "/usr/sony/share/data/images/BMP_TXT_SST/msg_cant_change_discs_now_Italian.png"
-      mount -o bind "$themes_path/$selected_theme/images/BMP_TXT_SST/msg_cant_change_discs_now_J.png" "/usr/sony/share/data/images/BMP_TXT_SST/msg_cant_change_discs_now_J.png"
-      mount -o bind "$themes_path/$selected_theme/images/BMP_TXT_SST/msg_cant_change_discs_now_Portuguese.png" "/usr/sony/share/data/images/BMP_TXT_SST/msg_cant_change_discs_now_Portuguese.png"
-      mount -o bind "$themes_path/$selected_theme/images/BMP_TXT_SST/msg_cant_change_discs_now_Portuguese_BR.png" "/usr/sony/share/data/images/BMP_TXT_SST/msg_cant_change_discs_now_Portuguese_BR.png"
-      mount -o bind "$themes_path/$selected_theme/images/BMP_TXT_SST/msg_cant_change_discs_now_Russian.png" "/usr/sony/share/data/images/BMP_TXT_SST/msg_cant_change_discs_now_Russian.png"
-      mount -o bind "$themes_path/$selected_theme/images/BMP_TXT_SST/msg_cant_change_discs_now_Spanish.png" "/usr/sony/share/data/images/BMP_TXT_SST/msg_cant_change_discs_now_Spanish.png"
-      mount -o bind "$themes_path/$selected_theme/images/BMP_TXT_SST/msg_cant_change_discs_now_Spanish_LA.png" "/usr/sony/share/data/images/BMP_TXT_SST/msg_cant_change_discs_now_Spanish_LA.png"
-      mount -o bind "$themes_path/$selected_theme/images/BMP_TXT_SST/msg_cant_change_discs_this_game_Dutch.png" "/usr/sony/share/data/images/BMP_TXT_SST/msg_cant_change_discs_this_game_Dutch.png"
-      mount -o bind "$themes_path/$selected_theme/images/BMP_TXT_SST/msg_cant_change_discs_this_game_E.png" "/usr/sony/share/data/images/BMP_TXT_SST/msg_cant_change_discs_this_game_E.png"
-      mount -o bind "$themes_path/$selected_theme/images/BMP_TXT_SST/msg_cant_change_discs_this_game_E_UK.png" "/usr/sony/share/data/images/BMP_TXT_SST/msg_cant_change_discs_this_game_E_UK.png"
-      mount -o bind "$themes_path/$selected_theme/images/BMP_TXT_SST/msg_cant_change_discs_this_game_French.png" "/usr/sony/share/data/images/BMP_TXT_SST/msg_cant_change_discs_this_game_French.png"
-      mount -o bind "$themes_path/$selected_theme/images/BMP_TXT_SST/msg_cant_change_discs_this_game_French_CA.png" "/usr/sony/share/data/images/BMP_TXT_SST/msg_cant_change_discs_this_game_French_CA.png"
-      mount -o bind "$themes_path/$selected_theme/images/BMP_TXT_SST/msg_cant_change_discs_this_game_German.png" "/usr/sony/share/data/images/BMP_TXT_SST/msg_cant_change_discs_this_game_German.png"
-      mount -o bind "$themes_path/$selected_theme/images/BMP_TXT_SST/msg_cant_change_discs_this_game_Italian.png" "/usr/sony/share/data/images/BMP_TXT_SST/msg_cant_change_discs_this_game_Italian.png"
-      mount -o bind "$themes_path/$selected_theme/images/BMP_TXT_SST/msg_cant_change_discs_this_game_J.png" "/usr/sony/share/data/images/BMP_TXT_SST/msg_cant_change_discs_this_game_J.png"
-      mount -o bind "$themes_path/$selected_theme/images/BMP_TXT_SST/msg_cant_change_discs_this_game_Portuguese.png" "/usr/sony/share/data/images/BMP_TXT_SST/msg_cant_change_discs_this_game_Portuguese.png"
-      mount -o bind "$themes_path/$selected_theme/images/BMP_TXT_SST/msg_cant_change_discs_this_game_Portuguese_BR.png" "/usr/sony/share/data/images/BMP_TXT_SST/msg_cant_change_discs_this_game_Portuguese_BR.png"
-      mount -o bind "$themes_path/$selected_theme/images/BMP_TXT_SST/msg_cant_change_discs_this_game_Russian.png" "/usr/sony/share/data/images/BMP_TXT_SST/msg_cant_change_discs_this_game_Russian.png"
-      mount -o bind "$themes_path/$selected_theme/images/BMP_TXT_SST/msg_cant_change_discs_this_game_Spanish.png" "/usr/sony/share/data/images/BMP_TXT_SST/msg_cant_change_discs_this_game_Spanish.png"
-      mount -o bind "$themes_path/$selected_theme/images/BMP_TXT_SST/msg_cant_change_discs_this_game_Spanish_LA.png" "/usr/sony/share/data/images/BMP_TXT_SST/msg_cant_change_discs_this_game_Spanish_LA.png"
-      mount -o bind "$themes_path/$selected_theme/images/BMP_TXT_SST/msg_current_inserted_disc_info_Dutch.png" "/usr/sony/share/data/images/BMP_TXT_SST/msg_current_inserted_disc_info_Dutch.png"
-      mount -o bind "$themes_path/$selected_theme/images/BMP_TXT_SST/msg_current_inserted_disc_info_E.png" "/usr/sony/share/data/images/BMP_TXT_SST/msg_current_inserted_disc_info_E.png"
-      mount -o bind "$themes_path/$selected_theme/images/BMP_TXT_SST/msg_current_inserted_disc_info_E_UK.png" "/usr/sony/share/data/images/BMP_TXT_SST/msg_current_inserted_disc_info_E_UK.png"
-      mount -o bind "$themes_path/$selected_theme/images/BMP_TXT_SST/msg_current_inserted_disc_info_French.png" "/usr/sony/share/data/images/BMP_TXT_SST/msg_current_inserted_disc_info_French.png"
-      mount -o bind "$themes_path/$selected_theme/images/BMP_TXT_SST/msg_current_inserted_disc_info_French_CA.png" "/usr/sony/share/data/images/BMP_TXT_SST/msg_current_inserted_disc_info_French_CA.png"
-      mount -o bind "$themes_path/$selected_theme/images/BMP_TXT_SST/msg_current_inserted_disc_info_German.png" "/usr/sony/share/data/images/BMP_TXT_SST/msg_current_inserted_disc_info_German.png"
-      mount -o bind "$themes_path/$selected_theme/images/BMP_TXT_SST/msg_current_inserted_disc_info_Italian.png" "/usr/sony/share/data/images/BMP_TXT_SST/msg_current_inserted_disc_info_Italian.png"
-      mount -o bind "$themes_path/$selected_theme/images/BMP_TXT_SST/msg_current_inserted_disc_info_J.png" "/usr/sony/share/data/images/BMP_TXT_SST/msg_current_inserted_disc_info_J.png"
-      mount -o bind "$themes_path/$selected_theme/images/BMP_TXT_SST/msg_current_inserted_disc_info_Portuguese.png" "/usr/sony/share/data/images/BMP_TXT_SST/msg_current_inserted_disc_info_Portuguese.png"
-      mount -o bind "$themes_path/$selected_theme/images/BMP_TXT_SST/msg_current_inserted_disc_info_Portuguese_BR.png" "/usr/sony/share/data/images/BMP_TXT_SST/msg_current_inserted_disc_info_Portuguese_BR.png"
-      mount -o bind "$themes_path/$selected_theme/images/BMP_TXT_SST/msg_current_inserted_disc_info_Russian.png" "/usr/sony/share/data/images/BMP_TXT_SST/msg_current_inserted_disc_info_Russian.png"
-      mount -o bind "$themes_path/$selected_theme/images/BMP_TXT_SST/msg_current_inserted_disc_info_Spanish.png" "/usr/sony/share/data/images/BMP_TXT_SST/msg_current_inserted_disc_info_Spanish.png"
-      mount -o bind "$themes_path/$selected_theme/images/BMP_TXT_SST/msg_current_inserted_disc_info_Spanish_LA.png" "/usr/sony/share/data/images/BMP_TXT_SST/msg_current_inserted_disc_info_Spanish_LA.png"
-      mount -o bind "$themes_path/$selected_theme/images/BTN/Guide_Dutch.png" "/usr/sony/share/data/images/BTN/Guide_Dutch.png"
-      mount -o bind "$themes_path/$selected_theme/images/BTN/Guide_E.png" "/usr/sony/share/data/images/BTN/Guide_E.png"
-      mount -o bind "$themes_path/$selected_theme/images/BTN/Guide_E_UK.png" "/usr/sony/share/data/images/BTN/Guide_E_UK.png"
-      mount -o bind "$themes_path/$selected_theme/images/BTN/Guide_French.png" "/usr/sony/share/data/images/BTN/Guide_French.png"
-      mount -o bind "$themes_path/$selected_theme/images/BTN/Guide_French_CA.png" "/usr/sony/share/data/images/BTN/Guide_French_CA.png"
-      mount -o bind "$themes_path/$selected_theme/images/BTN/Guide_German.png" "/usr/sony/share/data/images/BTN/Guide_German.png"
-      mount -o bind "$themes_path/$selected_theme/images/BTN/Guide_Italian.png" "/usr/sony/share/data/images/BTN/Guide_Italian.png"
-      mount -o bind "$themes_path/$selected_theme/images/BTN/Guide_J.png" "/usr/sony/share/data/images/BTN/Guide_J.png"
-      mount -o bind "$themes_path/$selected_theme/images/BTN/Guide_Portuguese.png" "/usr/sony/share/data/images/BTN/Guide_Portuguese.png"
-      mount -o bind "$themes_path/$selected_theme/images/BTN/Guide_Portuguese_BR.png" "/usr/sony/share/data/images/BTN/Guide_Portuguese_BR.png"
-      mount -o bind "$themes_path/$selected_theme/images/BTN/Guide_Russian.png" "/usr/sony/share/data/images/BTN/Guide_Russian.png"
-      mount -o bind "$themes_path/$selected_theme/images/BTN/Guide_Spanish.png" "/usr/sony/share/data/images/BTN/Guide_Spanish.png"
-      mount -o bind "$themes_path/$selected_theme/images/BTN/Guide_Spanish_LA.png" "/usr/sony/share/data/images/BTN/Guide_Spanish_LA.png"
-      mount -o bind "$themes_path/$selected_theme/images/CB/Contents_Focus.png" "/usr/sony/share/data/images/CB/Contents_Focus.png"
-      mount -o bind "$themes_path/$selected_theme/images/CB/Empty_L.png" "/usr/sony/share/data/images/CB/Empty_L.png"
-      mount -o bind "$themes_path/$selected_theme/images/CB/Empty_Screen.png" "/usr/sony/share/data/images/CB/Empty_Screen.png"
-      mount -o bind "$themes_path/$selected_theme/images/CB/Function_BG.png" "/usr/sony/share/data/images/CB/Function_BG.png"
-      mount -o bind "$themes_path/$selected_theme/images/CB/Manual_ICN _L.png" "/usr/sony/share/data/images/CB/Manual_ICN _L.png"
-      mount -o bind "$themes_path/$selected_theme/images/CB/Manual_ICN.png" "/usr/sony/share/data/images/CB/Manual_ICN.png"
-      mount -o bind "$themes_path/$selected_theme/images/CB/MemoryCard_ICN.png" "/usr/sony/share/data/images/CB/MemoryCard_ICN.png"
-      mount -o bind "$themes_path/$selected_theme/images/CB/MemoryCard_ICN_L.png" "/usr/sony/share/data/images/CB/MemoryCard_ICN_L.png"
-      mount -o bind "$themes_path/$selected_theme/images/CB/PlayerOne.png" "/usr/sony/share/data/images/CB/PlayerOne.png"
-      mount -o bind "$themes_path/$selected_theme/images/CB/Resume.png" "/usr/sony/share/data/images/CB/Resume.png"
-      mount -o bind "$themes_path/$selected_theme/images/CB/Resume_L.png" "/usr/sony/share/data/images/CB/Resume_L.png"
-      mount -o bind "$themes_path/$selected_theme/images/CB/Setting_ICN.png" "/usr/sony/share/data/images/CB/Setting_ICN.png"
-      mount -o bind "$themes_path/$selected_theme/images/CB/Setting_ICN_L.png" "/usr/sony/share/data/images/CB/Setting_ICN_L.png"
-      mount -o bind "$themes_path/$selected_theme/images/Disk/Ball_Btn_SD.png" "/usr/sony/share/data/images/Disk/Ball_Btn_SD.png"
-      mount -o bind "$themes_path/$selected_theme/images/Disk/Corrent_Disk.png" "/usr/sony/share/data/images/Disk/Corrent_Disk.png"
-      mount -o bind "$themes_path/$selected_theme/images/Disk/Nomal_Disk.png" "/usr/sony/share/data/images/Disk/Nomal_Disk.png"
-      mount -o bind "$themes_path/$selected_theme/images/Disk/OK_SD_Btn_Dutch.png" "/usr/sony/share/data/images/Disk/OK_SD_Btn_Dutch.png"
-      mount -o bind "$themes_path/$selected_theme/images/Disk/OK_SD_Btn_E.png" "/usr/sony/share/data/images/Disk/OK_SD_Btn_E.png"
-      mount -o bind "$themes_path/$selected_theme/images/Disk/OK_SD_Btn_E_UK.png" "/usr/sony/share/data/images/Disk/OK_SD_Btn_E_UK.png"
-      mount -o bind "$themes_path/$selected_theme/images/Disk/OK_SD_Btn_French.png" "/usr/sony/share/data/images/Disk/OK_SD_Btn_French.png"
-      mount -o bind "$themes_path/$selected_theme/images/Disk/OK_SD_Btn_French_CA.png" "/usr/sony/share/data/images/Disk/OK_SD_Btn_French_CA.png"
-      mount -o bind "$themes_path/$selected_theme/images/Disk/OK_SD_Btn_German.png" "/usr/sony/share/data/images/Disk/OK_SD_Btn_German.png"
-      mount -o bind "$themes_path/$selected_theme/images/Disk/OK_SD_Btn_Italian.png" "/usr/sony/share/data/images/Disk/OK_SD_Btn_Italian.png"
-      mount -o bind "$themes_path/$selected_theme/images/Disk/OK_SD_Btn_J.png" "/usr/sony/share/data/images/Disk/OK_SD_Btn_J.png"
-      mount -o bind "$themes_path/$selected_theme/images/Disk/OK_SD_Btn_Portuguese.png" "/usr/sony/share/data/images/Disk/OK_SD_Btn_Portuguese.png"
-      mount -o bind "$themes_path/$selected_theme/images/Disk/OK_SD_Btn_Portuguese_BR.png" "/usr/sony/share/data/images/Disk/OK_SD_Btn_Portuguese_BR.png"
-      mount -o bind "$themes_path/$selected_theme/images/Disk/OK_SD_Btn_Russian.png" "/usr/sony/share/data/images/Disk/OK_SD_Btn_Russian.png"
-      mount -o bind "$themes_path/$selected_theme/images/Disk/OK_SD_Btn_Spanish.png" "/usr/sony/share/data/images/Disk/OK_SD_Btn_Spanish.png"
-      mount -o bind "$themes_path/$selected_theme/images/Disk/OK_SD_Btn_Spanish_LA.png" "/usr/sony/share/data/images/Disk/OK_SD_Btn_Spanish_LA.png"
-      mount -o bind "$themes_path/$selected_theme/images/Disk/Select_Disk.png" "/usr/sony/share/data/images/Disk/Select_Disk.png"
-      mount -o bind "$themes_path/$selected_theme/images/Disk/Text_four.png" "/usr/sony/share/data/images/Disk/Text_four.png"
-      mount -o bind "$themes_path/$selected_theme/images/Disk/Text_one.png" "/usr/sony/share/data/images/Disk/Text_one.png"
-      mount -o bind "$themes_path/$selected_theme/images/Disk/Text_three.png" "/usr/sony/share/data/images/Disk/Text_three.png"
-      mount -o bind "$themes_path/$selected_theme/images/Disk/Text_two.png" "/usr/sony/share/data/images/Disk/Text_two.png"
-      mount -o bind "$themes_path/$selected_theme/images/GR/Acid_B_BTN.png" "/usr/sony/share/data/images/GR/Acid_B_BTN.png"
-      mount -o bind "$themes_path/$selected_theme/images/GR/Acid_C_Btn.png" "/usr/sony/share/data/images/GR/Acid_C_Btn.png"
-      mount -o bind "$themes_path/$selected_theme/images/GR/arrow.png" "/usr/sony/share/data/images/GR/arrow.png"
-      mount -o bind "$themes_path/$selected_theme/images/GR/Arrow_Right.png" "/usr/sony/share/data/images/GR/Arrow_Right.png"
-      mount -o bind "$themes_path/$selected_theme/images/GR/arrow_Up.png" "/usr/sony/share/data/images/GR/arrow_Up.png"
-      mount -o bind "$themes_path/$selected_theme/images/GR/Boarder_line.png" "/usr/sony/share/data/images/GR/Boarder_line.png"
-      mount -o bind "$themes_path/$selected_theme/images/GR/Circle_Btn_ICN.png" "/usr/sony/share/data/images/GR/Circle_Btn_ICN.png"
-      mount -o bind "$themes_path/$selected_theme/images/GR/Footer.png" "/usr/sony/share/data/images/GR/Footer.png"
-      mount -o bind "$themes_path/$selected_theme/images/GR/JP_US_BG Musk.png" "/usr/sony/share/data/images/GR/JP_US_BG Musk.png"
-      mount -o bind "$themes_path/$selected_theme/images/GR/JP_US_BG Musk_Helth.png" "/usr/sony/share/data/images/GR/JP_US_BG Musk_Helth.png"
-      mount -o bind "$themes_path/$selected_theme/images/GR/JP_US_BG Musk_Option.png" "/usr/sony/share/data/images/GR/JP_US_BG Musk_Option.png"
-      mount -o bind "$themes_path/$selected_theme/images/GR/JP_US_BG Musk_Regal.png" "/usr/sony/share/data/images/GR/JP_US_BG Musk_Regal.png"
-      mount -o bind "$themes_path/$selected_theme/images/GR/JP_US_BG.png" "/usr/sony/share/data/images/GR/JP_US_BG.png"
-      mount -o bind "$themes_path/$selected_theme/images/GR/Squere_Btn_ICN.png" "/usr/sony/share/data/images/GR/Squere_Btn_ICN.png"
-      mount -o bind "$themes_path/$selected_theme/images/GR/Tri_Btn_ICN.png" "/usr/sony/share/data/images/GR/Tri_Btn_ICN.png"
-      mount -o bind "$themes_path/$selected_theme/images/GR/X_Btn_ICN.png" "/usr/sony/share/data/images/GR/X_Btn_ICN.png"
-      mount -o bind "$themes_path/$selected_theme/images/MC/Ball_Btn.png" "/usr/sony/share/data/images/MC/Ball_Btn.png"
-      mount -o bind "$themes_path/$selected_theme/images/MC/Dot_Matrix.png" "/usr/sony/share/data/images/MC/Dot_Matrix.png"
-      mount -o bind "$themes_path/$selected_theme/images/MC/MC_Infobox.png" "/usr/sony/share/data/images/MC/MC_Infobox.png"
-      mount -o bind "$themes_path/$selected_theme/images/MC/Pencil_Carsor.png" "/usr/sony/share/data/images/MC/Pencil_Carsor.png"
-      mount -o bind "$themes_path/$selected_theme/images/SET/Border_Line.png" "/usr/sony/share/data/images/SET/Border_Line.png"
-      mount -o bind "$themes_path/$selected_theme/images/SET/Check.png" "/usr/sony/share/data/images/SET/Check.png"
-      mount -o bind "$themes_path/$selected_theme/images/SET/Lang_Btn_De.png" "/usr/sony/share/data/images/SET/Lang_Btn_De.png"
-      mount -o bind "$themes_path/$selected_theme/images/SET/Lang_Btn_Espa_Latin_America.png" "/usr/sony/share/data/images/SET/Lang_Btn_Espa_Latin_America.png"
-      mount -o bind "$themes_path/$selected_theme/images/SET/Lang_Btn_Espa_spain.png" "/usr/sony/share/data/images/SET/Lang_Btn_Espa_spain.png"
-      mount -o bind "$themes_path/$selected_theme/images/SET/Lang_Btn_E_uk.png" "/usr/sony/share/data/images/SET/Lang_Btn_E_uk.png"
-      mount -o bind "$themes_path/$selected_theme/images/SET/Lang_Btn_E_us.png" "/usr/sony/share/data/images/SET/Lang_Btn_E_us.png"
-      mount -o bind "$themes_path/$selected_theme/images/SET/Lang_Btn_Fr_Canada.png" "/usr/sony/share/data/images/SET/Lang_Btn_Fr_Canada.png"
-      mount -o bind "$themes_path/$selected_theme/images/SET/Lang_Btn_Fr_France.png" "/usr/sony/share/data/images/SET/Lang_Btn_Fr_France.png"
-      mount -o bind "$themes_path/$selected_theme/images/SET/Lang_Btn_Ita.png" "/usr/sony/share/data/images/SET/Lang_Btn_Ita.png"
-      mount -o bind "$themes_path/$selected_theme/images/SET/Lang_Btn_J.png" "/usr/sony/share/data/images/SET/Lang_Btn_J.png"
-      mount -o bind "$themes_path/$selected_theme/images/SET/Lang_Btn_Ned.png" "/usr/sony/share/data/images/SET/Lang_Btn_Ned.png"
-      mount -o bind "$themes_path/$selected_theme/images/SET/Lang_Btn_Nomal.png" "/usr/sony/share/data/images/SET/Lang_Btn_Nomal.png"
-      mount -o bind "$themes_path/$selected_theme/images/SET/Lang_Btn_Po_Brasil.png" "/usr/sony/share/data/images/SET/Lang_Btn_Po_Brasil.png"
-      mount -o bind "$themes_path/$selected_theme/images/SET/Lang_Btn_Po_Portugal.png" "/usr/sony/share/data/images/SET/Lang_Btn_Po_Portugal.png"
-      mount -o bind "$themes_path/$selected_theme/images/SET/Lang_Btn_Ros.png" "/usr/sony/share/data/images/SET/Lang_Btn_Ros.png"
-      mount -o bind "$themes_path/$selected_theme/images/SET/Lang_List_De.png" "/usr/sony/share/data/images/SET/Lang_List_De.png"
-      mount -o bind "$themes_path/$selected_theme/images/SET/Lang_List_Espa_Latin_America.png" "/usr/sony/share/data/images/SET/Lang_List_Espa_Latin_America.png"
-      mount -o bind "$themes_path/$selected_theme/images/SET/Lang_List_Espa_Spain.png" "/usr/sony/share/data/images/SET/Lang_List_Espa_Spain.png"
-      mount -o bind "$themes_path/$selected_theme/images/SET/Lang_List_E_UK.png" "/usr/sony/share/data/images/SET/Lang_List_E_UK.png"
-      mount -o bind "$themes_path/$selected_theme/images/SET/Lang_List_E_US.png" "/usr/sony/share/data/images/SET/Lang_List_E_US.png"
-      mount -o bind "$themes_path/$selected_theme/images/SET/Lang_List_Fr_Canada.png" "/usr/sony/share/data/images/SET/Lang_List_Fr_Canada.png"
-      mount -o bind "$themes_path/$selected_theme/images/SET/Lang_List_Fr_France.png" "/usr/sony/share/data/images/SET/Lang_List_Fr_France.png"
-      mount -o bind "$themes_path/$selected_theme/images/SET/Lang_List_Ita.png" "/usr/sony/share/data/images/SET/Lang_List_Ita.png"
-      mount -o bind "$themes_path/$selected_theme/images/SET/Lang_List_J.png" "/usr/sony/share/data/images/SET/Lang_List_J.png"
-      mount -o bind "$themes_path/$selected_theme/images/SET/Lang_List_Ned.png" "/usr/sony/share/data/images/SET/Lang_List_Ned.png"
-      mount -o bind "$themes_path/$selected_theme/images/SET/Lang_List_Po_Brasil.png" "/usr/sony/share/data/images/SET/Lang_List_Po_Brasil.png"
-      mount -o bind "$themes_path/$selected_theme/images/SET/Lang_List_Po_Portugal.png" "/usr/sony/share/data/images/SET/Lang_List_Po_Portugal.png"
-      mount -o bind "$themes_path/$selected_theme/images/SET/Lang_List_Ros.png" "/usr/sony/share/data/images/SET/Lang_List_Ros.png"
-      mount -o bind "$themes_path/$selected_theme/images/SET/Setting_Btn_Focus.png" "/usr/sony/share/data/images/SET/Setting_Btn_Focus.png"
-      mount -o bind "$themes_path/$selected_theme/images/SET/Setting_List_Focus.png" "/usr/sony/share/data/images/SET/Setting_List_Focus.png"
-      mount -o bind "$themes_path/$selected_theme/images/SET/Setting_List_Nomal.png" "/usr/sony/share/data/images/SET/Setting_List_Nomal.png"
-      mount -o bind "$themes_path/$selected_theme/images/SET/Setting_List_Selected.png" "/usr/sony/share/data/images/SET/Setting_List_Selected.png"
-      mount -o bind "$themes_path/$selected_theme/images/SET/Setting_Option_BG.png" "/usr/sony/share/data/images/SET/Setting_Option_BG.png"
-      mount -o bind "$themes_path/$selected_theme/images/SET/Setting_Option_List_Focus.png" "/usr/sony/share/data/images/SET/Setting_Option_List_Focus.png"
-      mount -o bind "$themes_path/$selected_theme/images/SET/Setting_Tittle_BG.png" "/usr/sony/share/data/images/SET/Setting_Tittle_BG.png"
-      echo "[BLEEMSYNC](INFO)(theme) mounting available image files"
-    else
-      echo "[BLEEMSYNC](INFO)(theme) no images folder found"
+      cd "$themes_path/$selected_theme/images"
+      for image_file in $(find -iname \*.png | sed -e 's,^\./,,'); do
+        mount -o bind "$themes_path/$selected_theme/images/$image_file" "/usr/sony/share/data/images/$image_file"
+        found_image_files=1
+      done
+      cd "/home/root"
     fi 2> /dev/null 
     # Check for the music folder
     if [ -d "$themes_path/$selected_theme/music" ] && [ "$override_theme_music" = "0" ]; then
-      mount -o bind "$themes_path/$selected_theme/music" "$sounds_path/music"
-      echo "[BLEEMSYNC](INFO)(theme) mounted music folder"
-    else
-      echo "[BLEEMSYNC](INFO)(theme) Using default music files"  
+      cd "$themes_path/$selected_theme/music"
+      for music_file in $(find -iname \*.wav | sed -e 's,^\./,,'); do
+        if [ ${music_file: -4} == ".wav" ]; then mount -o bind "$themes_path/$selected_theme/music" "$sounds_path/music"; found_music_files=1; fi
+      done
     fi 2> /dev/null 
     # Check for the sounds folder
     if [ -d "$themes_path/$selected_theme/sounds" ]; then
-      mount -o bind "$themes_path/$selected_theme/sounds/cancel.wav" "/usr/sony/share/data/sounds/cancel.wav"
-      mount -o bind "$themes_path/$selected_theme/sounds/cursor.wav" "/usr/sony/share/data/sounds/cursor.wav"
-      mount -o bind "$themes_path/$selected_theme/sounds/decide.wav" "/usr/sony/share/data/sounds/decide.wav"
-      mount -o bind "$themes_path/$selected_theme/sounds/end.wav" "/usr/sony/share/data/sounds/end.wav"
-      mount -o bind "$themes_path/$selected_theme/sounds/error.wav" "/usr/sony/share/data/sounds/error.wav"
-      mount -o bind "$themes_path/$selected_theme/sounds/home_down.wav" "/usr/sony/share/data/sounds/home_down.wav"
-      mount -o bind "$themes_path/$selected_theme/sounds/home_up.wav" "/usr/sony/share/data/sounds/home_up.wav"
-      mount -o bind "$themes_path/$selected_theme/sounds/resume_new.wav" "/usr/sony/share/data/sounds/resume_new.wav"
-      mount -o bind "$themes_path/$selected_theme/sounds/resume_old.wav" "/usr/sony/share/data/sounds/resume_old.wav"
-      echo "[BLEEMSYNC](INFO)(theme) mounting available sound files"
-    else
-      echo "[BLEEMSYNC](INFO)(theme) no sounds folder found"
-    fi 2> /dev/null 
+      cd "$themes_path/$selected_theme/sounds"
+      for sound_file in $(find -iname \*.wav | sed -e 's,^\./,,'); do
+        mount -o bind "$themes_path/$selected_theme/sounds/$sound_file" "/usr/sony/share/data/sounds/$sound_file"
+        found_sound_files=1
+      done
+      cd "/home/root"
+    fi 2> /dev/null     
+  fi
+  # log if stuff is found or not
+  if [ "$found_theme" == "1" ]; then
+    echo "[BLEEMSYNC](INFO)(theme) set theme to '$selected_theme' theme"
   else
     echo "[BLEEMSYNC](INFO)(theme) set theme to stock theme"
+  fi
+  if [ "$found_boot_files" == "1" ]; then
+    echo "[BLEEMSYNC](INFO)(theme) mounting available boot files"
+  else
+    echo "[BLEEMSYNC](INFO)(theme) mounting stock boot menu files"
+  fi
+  if [ "$found_font_files" == "1" ]; then
+    echo "[BLEEMSYNC](INFO)(theme) mounting available font files"
+  else
+    echo "[BLEEMSYNC](INFO)(theme) mounting stock font files"
+  fi
+  if [ "$found_image_files" == "1" ]; then
+    echo "[BLEEMSYNC](INFO)(theme) mounting available image files"
+  else
+    echo "[BLEEMSYNC](INFO)(theme) mounting stock image files"
+  fi
+  if [ "$found_music_files" == "1" ]; then
+    echo "[BLEEMSYNC](INFO)(theme) mounting available music files"
+  else
+    echo "[BLEEMSYNC](INFO)(theme) mounting stock music files"
+  fi
+  if [ "$found_sound_files" == "1" ]; then
+    echo "[BLEEMSYNC](INFO)(theme) mounting available sound files"
+  else
+    echo "[BLEEMSYNC](INFO)(theme) mounting stock sound files"
   fi
   echo 0 > /sys/class/leds/red/brightness
   end=$(date +%s%N)

--- a/Payload/bleemsync/etc/bleemsync/FUNC/0050_bleemsync.funcs
+++ b/Payload/bleemsync/etc/bleemsync/FUNC/0050_bleemsync.funcs
@@ -162,17 +162,6 @@ execute_bleemsync_func(){
   ln -s "$mountpoint/system/bios" "/var/volatile/gaadatatmp/system/bios"
   ln -s "$mountpoint/system/preferences/system" "/var/volatile/gaadatatmp/preferences"
 
-  i=1
-  for game in $mountpoint/games/*
-  do
-    if [ -d "${game}" ]; then
-      game_dir="${game}"
-      [ -d "${game_dir}/GameData" ] && game_dir="${game}/GameData"
-      ln -s "${game_dir}" /var/volatile/gaadatatmp/$i
-      i=$((i+1))
-    fi
-  done
-
   # Create data on tmpfs
   mkdir -p "/var/volatile/datatmp/sony/sgmo" "/var/volatile/datatmp/AppData/sony"
   # ln -s "/tmp/diag" "/tmp/datatmp/sony/sgmo/diag"
@@ -182,18 +171,22 @@ execute_bleemsync_func(){
   ln -s "$mountpoint/system/preferences/autodimmer" "/var/volatile/datatmp/AppData/sony/auto_dimmer"
   cp -fr "/usr/sony/share/recovery/AppData/sony/pcsx" "/var/volatile/datatmp/AppData/sony/pcsx"
 
+  PrevIFS="$IFS"
+  IFS=$'\t\r\n'
   i=1
-  for game in $mountpoint/games/*
+  for game in `ls -d -v -1 $mountpoint/games/**`
   do
     if [ -d "${game}" ]; then
       game_dir="${game}"
       [ -d "${game_dir}/GameData" ] && game_dir="${game}/GameData"
+      ln -s "${game_dir}" /var/volatile/gaadatatmp/$i
       rm -rf /var/volatile/datatmp/AppData/sony/pcsx/$i
       ln -s "${game_dir}" /var/volatile/datatmp/AppData/sony/pcsx/$i
       i=$((i+1))
     fi
   done
-
+  IFS="$PrevIFS"
+  
   ln -s "$mountpoint/system/bios" "/var/volatile/datatmp/AppData/sony/pcsx/bios"
   ln -s "/usr/sony/bin/plugins" "/var/volatile/datatmp/AppData/sony/pcsx/plugins"
 
@@ -261,6 +254,7 @@ execute_bleemsync_func(){
       game_dir="${game}"
       [ -d "${game_dir}/GameData" ] && game_dir="${game}/GameData"
       [ ! -f "${game_dir}/.pcsx/pcsx.cfg" ] && mkdir -p "${game_dir}/.pcsx" && cp -f "$mountpoint/system/defaults/pcsx.cfg" "${game_dir}/.pcsx/pcsx.cfg"
+	  mkdir -p "${game_dir}/.pcsx/cfg" "${game_dir}/.pcsx/cheats" "${game_dir}/.pcsx/memcards" "${game_dir}/.pcsx/patches" "${game_dir}/.pcsx/plugins" "${game_dir}/.pcsx/screenshots" "${game_dir}/.pcsx/sstates"
     fi
   done
 


### PR DESCRIPTION
Redone the theme.func file to use find for replacing ( overmounting ) files.
( you can comment-out line 59,60 and un-comment line 61,62 when Compcom updates the bootmenu )

Fixed games being parsed and symbolic links being out of whack.
Updated the code that adds the pcsx.cfg to new game folders to create all the sub folders for the .pcsx directory.