### PR TITLE
Script cleanup

### DIFF
--- a/Payload/bleemsync/bin/execute
+++ b/Payload/bleemsync/bin/execute
@@ -8,42 +8,39 @@
 ini_file="/media/bleemsync/etc/bleemsync/CFG/bleemsync_cfg.INI"
 cfg_file="/var/volatile/bleemsync.cfg"
 
-[ -f "$cfg_file" ] && rm -f "$cfg_file" && touch "$cfg_file"
-echo "#!/bin/sh" >> "$cfg_file"
-cat "$ini_file" | grep -v ";" | grep -v "\[" >> "$cfg_file"
+rm -f "$cfg_file"
+grep -v -e "^;" -e "^\[" "$ini_file" > "$cfg_file"
 
 if [ -f "$cfg_file" ]; then
-  . "$cfg_file"
+  source "$cfg_file"
 else
   echo "wtf" #Add a proper error at some point here...
 fi
 
-source "/media/bleemsync/etc/bleemsync/CFG/boot_sequence.cfg"
+source "${bleemsync_path}/etc/bleemsync/CFG/boot_sequence.cfg"
+
+# Set up logging
+if [ "$runtime_log" = "1" ]; then
+  error_log="$runtime_log_path/bleemsync.log"
+else
+  error_log="/dev/stdout"
+fi
 
 ### LOAD FUNCTION LIBRARIES ###################################################												  
 for funcs in /media/bleemsync/etc/bleemsync/FUNC/*.funcs; do source "$funcs"; done
 
 ### EXECUTE ###################################################################
 main(){
-  start=$(date +%s)
   for x in "${boot_sequence[@]}"; do
-    [ "$runtime_log" = "1" ] && echo "[BLEEMSYNC](BOOT) booting "$x"_func()" >> "$runtime_log_path/bleemsync.log" 2>&1
+    echo "[BLEEMSYNC](BOOT) booting "$x"_func()" >> "${error_log}"
     time1=$(date +%s%N)
-    if [ "$runtime_log" = "1" ]; then
-      if [ ! -z $(echo "$x" | grep "dump_") ] && [ "$force_redump" = "1" ]; then
-        $x"_func" --force >> "$runtime_log_path/bleemsync.log" 2>&1
-        continue
-      fi
-      $x"_func" >> "$runtime_log_path/bleemsync.log" 2>&1
+    if [ ! -z $(echo "$x" | grep "^dump_") ] && [ "$force_redump" = "1" ]; then
+      $x"_func" --force >> "${error_log}" 2>&1
     else
-      if [ ! -z $(echo "$x" | grep "dump_") ] && [ "$force_redump" = "1" ]; then
-        $x"_func" --force
-        continue
-      fi  
-      $x"_func" 
+      $x"_func" >> "${error_log}" 2>&1
     fi
     time2=$(date +%s%N)
-    [ "$runtime_log" = "1" ] && echo "[BLEEMSYNC](PROFILE) "$x"_func() took: $(((time1-time2)/1000000))ms to execute" >> "$runtime_log_path/bleemsync.log" 2>&1
+    echo "[BLEEMSYNC](PROFILE) "$x"_func() took: $(((time1-time2)/1000000))ms to execute" >> "${error_log}"
   done 
 }
 

--- a/Payload/bleemsync/etc/bleemsync/CFG/bleemsync_cfg.INI
+++ b/Payload/bleemsync/etc/bleemsync/CFG/bleemsync_cfg.INI
@@ -1,3 +1,19 @@
+;  Copyright 2019 ModMyClassic (https://modmyclassic.com/license)
+;  
+;  This program is free software: you can redistribute it and/or modify
+;  it under the terms of the GNU General Public License as published by
+;  the Free Software Foundation, either version 3 of the License, or
+;  (at your option) any later version.
+;  
+;  This program is distributed in the hope that it will be useful,
+;  but WITHOUT ANY WARRANTY; without even the implied warranty of
+;  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;  GNU General Public License for more details.
+;  
+;  You should have received a copy of the GNU General Public License
+;  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+;
+
 ;#############################################################################;
 ; BleemSync (config) v"0".7
 ; ModMyClassic.com / https://discordapp.com/invite/8gygsrw

--- a/Payload/bleemsync/etc/bleemsync/CFG/boot_sequence.cfg
+++ b/Payload/bleemsync/etc/bleemsync/CFG/boot_sequence.cfg
@@ -1,4 +1,21 @@
 #!/bin/sh
+#
+#  Copyright 2019 ModMyClassic (https://modmyclassic.com/license)
+#  
+#  This program is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#  
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#  
+#  You should have received a copy of the GNU General Public License
+#  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+
 ###############################################################################
 # BleemSync (boot sequence config) v0.7
 # ModMyClassic.com / https://discordapp.com/invite/8gygsrw
@@ -20,8 +37,7 @@
 ### BOOT SEQUENCE #############################################################
 ###############################################################################
 boot_sequence=(
-    "pretty_logo" \
-    "execute_bleemsync" 
+  "pretty_logo" \
+  "execute_bleemsync" 
 )
 ###############################################################################
-

--- a/Payload/bleemsync/etc/bleemsync/FUNC/0000_shared.funcs
+++ b/Payload/bleemsync/etc/bleemsync/FUNC/0000_shared.funcs
@@ -1,4 +1,21 @@
 #!/bin/sh
+#
+#  Copyright 2019 ModMyClassic (https://modmyclassic.com/license)
+#
+#  This program is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+
 ###############################################################################
 # BleemSync Function Library - Shared
 # ModMyClassic.com / https://discordapp.com/invite/8gygsrw

--- a/Payload/bleemsync/etc/bleemsync/FUNC/0000_shared.funcs
+++ b/Payload/bleemsync/etc/bleemsync/FUNC/0000_shared.funcs
@@ -5,16 +5,17 @@
 ###############################################################################
 
 pretty_logo_func(){ #ASCII PORN
-	bin=$bleemsync_path/etc/bleemsync/SUP/scripts/show_logo
-	chmod +x $bin && $bin
+	bin="$bleemsync_path/etc/bleemsync/SUP/scripts/show_logo"
+	chmod +x "$bin" && "$bin"
 }
 
-red_led_flash () {
+red_led_flash() {
   SLEEP=1
-  echo 0 > /sys/class/leds/green/brightness
   while true; do
+    echo 0 > /sys/class/leds/green/brightness
     echo 1 > /sys/class/leds/red/brightness
     sleep $SLEEP
+    echo 0 > /sys/class/leds/green/brightness
     echo 0 > /sys/class/leds/red/brightness
     sleep $SLEEP
   done

--- a/Payload/bleemsync/etc/bleemsync/FUNC/0010_execute.funcs
+++ b/Payload/bleemsync/etc/bleemsync/FUNC/0010_execute.funcs
@@ -10,9 +10,9 @@ dump_emmc_func(){
 		echo 1 > /sys/class/leds/red/brightness
 		ok=1
 		mediafs="$(df -T | grep -Ee ' /media$' | awk -e '{ print $2 }')"
-		[ ! -d "$dump_path/emmc_RAW" ] && mkdir -p "$dump_path/emmc_RAW"
+		mkdir -p "$dump_path/emmc_RAW"
 		mount -o remount,ro /data && mount -o remount,ro /gaadata
-		if [ "$mediafs" == "vfat" ]; then
+		if [ "$mediafs" = "vfat" ]; then
 			if ! dd if=/dev/mmcblk0 bs=1M | gzip | split -a3 -b4294967295 - "$dump_path/emmc_RAW/mmcblk0.bin.gz."; then
 				ok=0
 			fi
@@ -41,10 +41,10 @@ dump_fs_func(){
 		echo 1 > /sys/class/leds/red/brightness
 		ok=1
 		mediafs="$(df -T | grep -Ee ' /media$' | awk -e '{ print $2 }')"
-		[ ! -d "$dump_path/emmc_FS" ] && mkdir -p "$dump_path/emmc_FS"
+		mkdir -p "$dump_path/emmc_FS"
 		mount -o remount,ro /data && mount -o remount,ro /gaadata
-		if [ "$mediafs" == "vfat" ]; then
-			if ! dd if=/dev/mmcblk0 bs=1M | gzip | split -a3 -b4294967295 - "$dump_path/emmc_FS/gaadata.bin.gz."; then
+		if [ "$mediafs" = "vfat" ]; then
+			if ! dd if=/dev/mapper/gaadata bs=1M | gzip | split -a3 -b4294967295 - "$dump_path/emmc_FS/gaadata.bin.gz."; then
 				ok=0
 			fi
 		else
@@ -52,11 +52,10 @@ dump_fs_func(){
 				ok=0
 			fi
 		fi
-		if ! dd if=/dev/mmcblk0p10 bs=1M > "$dump_path/emmc_FS/data.bin"; then
+		if ! dd if=/dev/disk/by-partlabel/USRDATA bs=1M > "$dump_path/emmc_FS/data.bin"; then
 			ok=0
 		fi
-		rootdevice="$(mount | grep ' on / ' | awk -e '{ print $1 }')"
-		if ! dd "if=$rootdevice" bs=1M > "$dump_path/emmc_FS/root.bin"; then
+		if ! dd if=/dev/disk/by-partlabel/ROOTFS1 bs=1M > "$dump_path/emmc_FS/root.bin"; then
 			ok=0
 		fi
 		if [ "$ok" = "1" ]; then
@@ -65,6 +64,7 @@ dump_fs_func(){
 		else
 			echo "[BLEEMSYNC](FAIL) dump_fs_func()"
 		fi
+		mount -o remount,rw /data
 		sync
 		echo 0 > /sys/class/leds/red/brightness
 	else 
@@ -79,9 +79,9 @@ dump_tar_func(){
 		echo 1 > /sys/class/leds/red/brightness
 		ok=1
 		mediafs="$(df -T | grep -Ee ' /media$' | awk -e '{ print $2 }')"
-		[ ! -d "$dump_path/emmc_TAR" ] && mkdir -p "$dump_path/emmc_TAR"
+		mkdir -p "$dump_path/emmc_TAR"
 		mount -o remount,ro /data && mount -o remount,ro /gaadata
-		if [ "$mediafs" == "vfat" ]; then
+		if [ "$mediafs" = "vfat" ]; then
 			if ! tar -czf - -C "/gaadata" . | split -a3 -b4294967295 - "$dump_path/emmc_TAR/gaadata.tar.gz."; then
 				ok=0
 			fi
@@ -93,9 +93,8 @@ dump_tar_func(){
 		if ! tar -czf - -C "/data" . > "$dump_path/emmc_TAR/data.tar.gz"; then
 			ok=0
 		fi
-		rootdevice="$(mount | grep ' on / ' | awk -e '{ print $1 }')"
 		mkdir -p "/tmp/root"
-		mount -o ro "$rootdevice" "/tmp/root"
+		mount -o ro /dev/disk/by-partlabel/ROOTFS1 "/tmp/root"
 		if ! tar -czf - -C "/tmp/root" . > "$dump_path/emmc_TAR/root.tar.gz"; then
 			ok=0
 		fi
@@ -121,7 +120,7 @@ dump_fstruct_func(){
 		echo 1 > /sys/class/leds/red/brightness
 		echo "Dumping file structure to: $dump_path/PSC_file_structure.txt"
 		echo "This might take awhile!"
-		[ ! -d "$dump_path" ] && mkdir -p "$dump_path"
+		mkdir -p "$dump_path"
 		ls -lhAR / &> "$dump_path/PSC_file_structure.txt"
 		[ -f "$dump_path/PSC_file_structure.txt" ] && touch "$runtime_flag_path/dumped_fstruct.flag"
 		echo 0 > /sys/class/leds/red/brightness
@@ -135,8 +134,8 @@ debug_run_func(){
 	#Misc debugging commands get dumped here.
 	echo "[BLEEMSYNC](Executing) debug_run_func()"
 	echo 1 > /sys/class/leds/red/brightness
-	[ ! -d "$dump_path" ] && mkdir -p "$dump_path"
-	touch "$dump_path/mount.log" && mount &> "$dump_path/mount.log"
+	mkdir -p "$dump_path"
+	mount &> "$dump_path/mount.log"
 	[ -d "$dump_path/DEBUG" ] && rm -rf "$dump_path/DEBUG"
 	[ ! -d "$dump_path/DEBUG" ] && mkdir -p "$dump_path/DEBUG"
 	cat "/proc/mtktz/mtktscpu" | head -1 &> "$dump_path/DEBUG/CPUTEMP.log"

--- a/Payload/bleemsync/etc/bleemsync/FUNC/0010_execute.funcs
+++ b/Payload/bleemsync/etc/bleemsync/FUNC/0010_execute.funcs
@@ -1,150 +1,167 @@
 #!/bin/sh
+#
+#  Copyright 2019 ModMyClassic (https://modmyclassic.com/license)
+#
+#  This program is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+
 ###############################################################################
 # BleemSync Function Library - Execution
 # ModMyClassic.com / https://discordapp.com/invite/8gygsrw
 ###############################################################################
 
 dump_emmc_func(){
-	echo "[BLEEMSYNC](Executing) dump_emmc_func()"
-	if [ ! -f "$runtime_flag_path/dumped_emmc.flag" ] || [ "$1" = "--force" ]; then
-		echo 1 > /sys/class/leds/red/brightness
-		ok=1
-		mediafs="$(df -T | grep -Ee ' /media$' | awk -e '{ print $2 }')"
-		mkdir -p "$dump_path/emmc_RAW"
-		mount -o remount,ro /data && mount -o remount,ro /gaadata
-		if [ "$mediafs" = "vfat" ]; then
-			if ! dd if=/dev/mmcblk0 bs=1M | gzip | split -a3 -b4294967295 - "$dump_path/emmc_RAW/mmcblk0.bin.gz."; then
-				ok=0
-			fi
-		else
-			if ! dd if=/dev/mmcblk0 bs=1M | gzip > "$dump_path/emmc_RAW/mmcblk0.bin.gz"; then
-				ok=0
-			fi
-		fi
-		if [ "$ok" = "1" ]; then
-			touch "$runtime_flag_path/dumped_emmc.flag"
-			echo "[BLEEMSYNC](SUCCESS) dump_emmc_func()"
-		else
-			echo "[BLEEMSYNC](FAIL) dump_emmc_func()"
-		fi
-		sync
-		echo 0 > /sys/class/leds/red/brightness
-	else 
-		echo "[BLEEMSYNC](INFO) Skipping as dump flag already present" 
-	fi
-	echo "[BLEEMSYNC](Executed) dump_emmc_func()"
+  echo "[BLEEMSYNC](Executing) dump_emmc_func()"
+  if [ ! -f "$runtime_flag_path/dumped_emmc.flag" ] || [ "$1" = "--force" ]; then
+    echo 1 > /sys/class/leds/red/brightness
+    ok=1
+    mediafs="$(df -T | grep -Ee ' /media$' | awk -e '{ print $2 }')"
+    mkdir -p "$dump_path/emmc_RAW"
+    mount -o remount,ro /data && mount -o remount,ro /gaadata
+    if [ "$mediafs" = "vfat" ]; then
+      if ! dd if=/dev/mmcblk0 bs=1M | gzip | split -a3 -b4294967295 - "$dump_path/emmc_RAW/mmcblk0.bin.gz."; then
+        ok=0
+      fi
+    else
+      if ! dd if=/dev/mmcblk0 bs=1M | gzip > "$dump_path/emmc_RAW/mmcblk0.bin.gz"; then
+        ok=0
+      fi
+    fi
+    if [ "$ok" = "1" ]; then
+      touch "$runtime_flag_path/dumped_emmc.flag"
+      echo "[BLEEMSYNC](SUCCESS) dump_emmc_func()"
+    else
+      echo "[BLEEMSYNC](FAIL) dump_emmc_func()"
+    fi
+    sync
+    echo 0 > /sys/class/leds/red/brightness
+  else
+    echo "[BLEEMSYNC](INFO) Skipping as dump flag already present"
+  fi
+  echo "[BLEEMSYNC](Executed) dump_emmc_func()"
 }
 
 dump_fs_func(){
-	echo "[BLEEMSYNC](Executing) dump_fs_func()"
-	if [ ! -f "$runtime_flag_path/dumped_fs.flag" ] || [ "$1" = "--force" ]; then
-		echo 1 > /sys/class/leds/red/brightness
-		ok=1
-		mediafs="$(df -T | grep -Ee ' /media$' | awk -e '{ print $2 }')"
-		mkdir -p "$dump_path/emmc_FS"
-		mount -o remount,ro /data && mount -o remount,ro /gaadata
-		if [ "$mediafs" = "vfat" ]; then
-			if ! dd if=/dev/mapper/gaadata bs=1M | gzip | split -a3 -b4294967295 - "$dump_path/emmc_FS/gaadata.bin.gz."; then
-				ok=0
-			fi
-		else
-			if ! dd if=/dev/mapper/gaadata bs=1M > "$dump_path/emmc_FS/gaadata.bin"; then
-				ok=0
-			fi
-		fi
-		if ! dd if=/dev/disk/by-partlabel/USRDATA bs=1M > "$dump_path/emmc_FS/data.bin"; then
-			ok=0
-		fi
-		if ! dd if=/dev/disk/by-partlabel/ROOTFS1 bs=1M > "$dump_path/emmc_FS/root.bin"; then
-			ok=0
-		fi
-		if [ "$ok" = "1" ]; then
-			touch "$runtime_flag_path/dumped_fs.flag"
-			echo "[BLEEMSYNC](SUCCESS) dump_fs_func()"
-		else
-			echo "[BLEEMSYNC](FAIL) dump_fs_func()"
-		fi
-		mount -o remount,rw /data
-		sync
-		echo 0 > /sys/class/leds/red/brightness
-	else 
-		echo "[BLEEMSYNC](INFO) Skipping as dump flag already present" 
-	fi
-	echo "[BLEEMSYNC](Executed) dump_fs_func()"
+  echo "[BLEEMSYNC](Executing) dump_fs_func()"
+  if [ ! -f "$runtime_flag_path/dumped_fs.flag" ] || [ "$1" = "--force" ]; then
+    echo 1 > /sys/class/leds/red/brightness
+    ok=1
+    mediafs="$(df -T | grep -Ee ' /media$' | awk -e '{ print $2 }')"
+    mkdir -p "$dump_path/emmc_FS"
+    mount -o remount,ro /data && mount -o remount,ro /gaadata
+    if [ "$mediafs" = "vfat" ]; then
+      if ! dd if=/dev/mapper/gaadata bs=1M | gzip | split -a3 -b4294967295 - "$dump_path/emmc_FS/gaadata.bin.gz."; then
+        ok=0
+      fi
+    else
+      if ! dd if=/dev/mapper/gaadata bs=1M > "$dump_path/emmc_FS/gaadata.bin"; then
+        ok=0
+      fi
+    fi
+    if ! dd if=/dev/disk/by-partlabel/USRDATA bs=1M > "$dump_path/emmc_FS/data.bin"; then
+      ok=0
+    fi
+    if ! dd if=/dev/disk/by-partlabel/ROOTFS1 bs=1M > "$dump_path/emmc_FS/root.bin"; then
+      ok=0
+    fi
+    if [ "$ok" = "1" ]; then
+      touch "$runtime_flag_path/dumped_fs.flag"
+      echo "[BLEEMSYNC](SUCCESS) dump_fs_func()"
+    else
+      echo "[BLEEMSYNC](FAIL) dump_fs_func()"
+    fi
+    mount -o remount,rw /data
+    sync
+    echo 0 > /sys/class/leds/red/brightness
+  else
+    echo "[BLEEMSYNC](INFO) Skipping as dump flag already present"
+  fi
+  echo "[BLEEMSYNC](Executed) dump_fs_func()"
 }
 
 dump_tar_func(){
-	echo "[BLEEMSYNC](Executing) dump_tar_func()"
-	if [ ! -f "$runtime_flag_path/dumped_tar.flag" ] || [ "$1" = "--force" ]; then
-		echo 1 > /sys/class/leds/red/brightness
-		ok=1
-		mediafs="$(df -T | grep -Ee ' /media$' | awk -e '{ print $2 }')"
-		mkdir -p "$dump_path/emmc_TAR"
-		mount -o remount,ro /data && mount -o remount,ro /gaadata
-		if [ "$mediafs" = "vfat" ]; then
-			if ! tar -czf - -C "/gaadata" . | split -a3 -b4294967295 - "$dump_path/emmc_TAR/gaadata.tar.gz."; then
-				ok=0
-			fi
-		else
-			if ! tar -czf - -C "/gaadata" . > "$dump_path/emmc_TAR/gaadata.tar.gz"; then
-				ok=0
-			fi
-		fi
-		if ! tar -czf - -C "/data" . > "$dump_path/emmc_TAR/data.tar.gz"; then
-			ok=0
-		fi
-		mkdir -p "/tmp/root"
-		mount -o ro /dev/disk/by-partlabel/ROOTFS1 "/tmp/root"
-		if ! tar -czf - -C "/tmp/root" . > "$dump_path/emmc_TAR/root.tar.gz"; then
-			ok=0
-		fi
-		umount "/tmp/root"
-		rmdir "/tmp/root"		
-		if [ "$ok" = "1" ]; then
-			touch "$runtime_flag_path/dumped_tar.flag"
-			echo "[BLEEMSYNC](SUCCESS) dump_tar_func()"
-		else
-			echo "[BLEEMSYNC](FAIL) dump_tar_func()"
-		fi
-		sync
-		echo 0 > /sys/class/leds/red/brightness
-	else 
-		echo "[BLEEMSYNC](INFO) Skipping as dump flag already present" 
-	fi
-	echo "[BLEEMSYNC](Executed) dump_tar_func()"
+  echo "[BLEEMSYNC](Executing) dump_tar_func()"
+  if [ ! -f "$runtime_flag_path/dumped_tar.flag" ] || [ "$1" = "--force" ]; then
+    echo 1 > /sys/class/leds/red/brightness
+    ok=1
+    mediafs="$(df -T | grep -Ee ' /media$' | awk -e '{ print $2 }')"
+    mkdir -p "$dump_path/emmc_TAR"
+    mount -o remount,ro /data && mount -o remount,ro /gaadata
+    if [ "$mediafs" = "vfat" ]; then
+      if ! tar -czf - -C "/gaadata" . | split -a3 -b4294967295 - "$dump_path/emmc_TAR/gaadata.tar.gz."; then
+        ok=0
+      fi
+    else
+      if ! tar -czf - -C "/gaadata" . > "$dump_path/emmc_TAR/gaadata.tar.gz"; then
+        ok=0
+      fi
+    fi
+    if ! tar -czf - -C "/data" . > "$dump_path/emmc_TAR/data.tar.gz"; then
+      ok=0
+    fi
+    mkdir -p "/tmp/root"
+    mount -o ro /dev/disk/by-partlabel/ROOTFS1 "/tmp/root"
+    if ! tar -czf - -C "/tmp/root" . > "$dump_path/emmc_TAR/root.tar.gz"; then
+      ok=0
+    fi
+    umount "/tmp/root"
+    rmdir "/tmp/root"
+    if [ "$ok" = "1" ]; then
+      touch "$runtime_flag_path/dumped_tar.flag"
+      echo "[BLEEMSYNC](SUCCESS) dump_tar_func()"
+    else
+      echo "[BLEEMSYNC](FAIL) dump_tar_func()"
+    fi
+    sync
+    echo 0 > /sys/class/leds/red/brightness
+  else
+    echo "[BLEEMSYNC](INFO) Skipping as dump flag already present"
+  fi
+  echo "[BLEEMSYNC](Executed) dump_tar_func()"
 }
 
 dump_fstruct_func(){
-	echo "[BLEEMSYNC](Executing) dump_file_structure()"
-	if [ ! -f "$runtime_flag_path/dumped_fstruct.flag" ] || [ "$1" = "--force" ]; then
-		echo 1 > /sys/class/leds/red/brightness
-		echo "Dumping file structure to: $dump_path/PSC_file_structure.txt"
-		echo "This might take awhile!"
-		mkdir -p "$dump_path"
-		ls -lhAR / &> "$dump_path/PSC_file_structure.txt"
-		[ -f "$dump_path/PSC_file_structure.txt" ] && touch "$runtime_flag_path/dumped_fstruct.flag"
-		echo 0 > /sys/class/leds/red/brightness
-	else 
-		echo "[BLEEMSYNC](INFO) Skipping as dump flag already present" 
-	fi
-	echo "[BLEEMSYNC](Executed) dump_file_structure()"
+  echo "[BLEEMSYNC](Executing) dump_file_structure()"
+  if [ ! -f "$runtime_flag_path/dumped_fstruct.flag" ] || [ "$1" = "--force" ]; then
+    echo 1 > /sys/class/leds/red/brightness
+    echo "Dumping file structure to: $dump_path/PSC_file_structure.txt"
+    echo "This might take awhile!"
+    mkdir -p "$dump_path"
+    ls -lhAR / &> "$dump_path/PSC_file_structure.txt"
+    [ -f "$dump_path/PSC_file_structure.txt" ] && touch "$runtime_flag_path/dumped_fstruct.flag"
+    echo 0 > /sys/class/leds/red/brightness
+  else
+    echo "[BLEEMSYNC](INFO) Skipping as dump flag already present"
+  fi
+  echo "[BLEEMSYNC](Executed) dump_file_structure()"
 }
 
 debug_run_func(){
-	#Misc debugging commands get dumped here.
-	echo "[BLEEMSYNC](Executing) debug_run_func()"
-	echo 1 > /sys/class/leds/red/brightness
-	mkdir -p "$dump_path"
-	mount &> "$dump_path/mount.log"
-	[ -d "$dump_path/DEBUG" ] && rm -rf "$dump_path/DEBUG"
-	[ ! -d "$dump_path/DEBUG" ] && mkdir -p "$dump_path/DEBUG"
-	cat "/proc/mtktz/mtktscpu" | head -1 &> "$dump_path/DEBUG/CPUTEMP.log"
-	cat "/proc/mtktz/mtktspmic" | head -1 &> "$dump_path/DEBUG/PMICTEMP.log"
-	cat "/proc/mtktz/mtktsAP" | head -1 &> "$dump_path/DEBUG/APTEMP.log"
-	cat "/proc/mtktz/mtktscpu" | tail -1 | grep "Tfake" | sed 's/.*/Tfake/' &> "$dump_path/DEBUG/CPUTEMPFAKE.log"
-	cat "/proc/mtktz/mtktspmic" | tail -1 | grep "Tfake" | sed 's/.*/Tfake/' &> "$dump_path/DEBUG/PMICTEMPFAKE.log"
-	cat "/proc/mtktz/mtktsAP" | tail -1 | grep "Tfake" | sed 's/.*/Tfake/' &> "$dump_path/DEBUG/APTEMPFAKE.log"
-	/usr/share/misc/sony/cpu_mode &> "$dump_path/DEBUG/cpu_mode.log"
-	echo 0 > /sys/class/leds/red/brightness
-	echo "[BLEEMSYNC](Executed) debug_run_func()"
+  #Misc debugging commands get dumped here.
+  echo "[BLEEMSYNC](Executing) debug_run_func()"
+  echo 1 > /sys/class/leds/red/brightness
+  mkdir -p "$dump_path"
+  mount &> "$dump_path/mount.log"
+  [ -d "$dump_path/DEBUG" ] && rm -rf "$dump_path/DEBUG"
+  [ ! -d "$dump_path/DEBUG" ] && mkdir -p "$dump_path/DEBUG"
+  cat "/proc/mtktz/mtktscpu" | head -1 &> "$dump_path/DEBUG/CPUTEMP.log"
+  cat "/proc/mtktz/mtktspmic" | head -1 &> "$dump_path/DEBUG/PMICTEMP.log"
+  cat "/proc/mtktz/mtktsAP" | head -1 &> "$dump_path/DEBUG/APTEMP.log"
+  cat "/proc/mtktz/mtktscpu" | tail -1 | grep "Tfake" | sed 's/.*/Tfake/' &> "$dump_path/DEBUG/CPUTEMPFAKE.log"
+  cat "/proc/mtktz/mtktspmic" | tail -1 | grep "Tfake" | sed 's/.*/Tfake/' &> "$dump_path/DEBUG/PMICTEMPFAKE.log"
+  cat "/proc/mtktz/mtktsAP" | tail -1 | grep "Tfake" | sed 's/.*/Tfake/' &> "$dump_path/DEBUG/APTEMPFAKE.log"
+  /usr/share/misc/sony/cpu_mode &> "$dump_path/DEBUG/cpu_mode.log"
+  echo 0 > /sys/class/leds/red/brightness
+  echo "[BLEEMSYNC](Executed) debug_run_func()"
 }

--- a/Payload/bleemsync/etc/bleemsync/FUNC/0030_retroarch.funcs
+++ b/Payload/bleemsync/etc/bleemsync/FUNC/0030_retroarch.funcs
@@ -1,4 +1,21 @@
 #!/bin/sh
+#
+#  Copyright 2019 ModMyClassic (https://modmyclassic.com/license)
+#
+#  This program is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+
 ###############################################################################
 # BleemSync Function Library - RetroArch
 # ModMyClassic.com / https://discordapp.com/invite/8gygsrw
@@ -27,7 +44,7 @@ launch_retroarch_from_StockUI(){
   start=$(date +%s%N)
   echo "[BLEEMSYNC](INFO) Launching RetroArch from ui_menu"
   #  Check RA Exists and is configured correctly
-  rm -f "$runtime_log_path/retroarch.log" 
+  rm -f "$runtime_log_path/retroarch.log"
   [ ! -f "$retroarch_path/retroarch" ] && break #FAIL
   if [ ! -f "$retroarch_path/system/scph102b.bin" ]; then
     cp -f "/gaadata/system/bios/romw.bin" "$retroarch_path/system/scph102b.bin"
@@ -70,7 +87,7 @@ exit_checkSaveState(){
   # An auto save state is created automatically, but what if the game disc was changed since
   # retroarch was originally launched. Check that the last saved state matches the ID of the launching
   # game
-    
+
   ra_last_game=`ls -t "${ra_savestate_path}/"*.auto | head -1`
 
   if [ x"$ra_last_game" = x"" ]; then
@@ -83,7 +100,7 @@ exit_checkSaveState(){
   ra_last_game="${ra_last_game##*/}"          # Remove leading directories
   ra_last_game="${ra_last_game%.state.auto}"  # Remove trailing file extension .state.auto
 
-  if [ ! "$ra_last_game" = "$intercept_game_id" ]; then    
+  if [ ! "$ra_last_game" = "$intercept_game_id" ]; then
     #  The last save state was for a different game, check if this disc belongs to the launching game
     #  If it does then a disc swap has occured, so update the game ids so the correct save state
     #  data is passed to ui_menu state is from a game which is different to the launched game"

--- a/Payload/bleemsync/etc/bleemsync/FUNC/0030_retroarch.funcs
+++ b/Payload/bleemsync/etc/bleemsync/FUNC/0030_retroarch.funcs
@@ -27,7 +27,7 @@ launch_retroarch_from_StockUI(){
   start=$(date +%s%N)
   echo "[BLEEMSYNC](INFO) Launching RetroArch from ui_menu"
   #  Check RA Exists and is configured correctly
-  [ -f "$runtime_log_path/retroarch.log" ] && rm -f "$runtime_log_path/retroarch.log" 
+  rm -f "$runtime_log_path/retroarch.log" 
   [ ! -f "$retroarch_path/retroarch" ] && break #FAIL
   if [ ! -f "$retroarch_path/system/scph102b.bin" ]; then
     cp -f "/gaadata/system/bios/romw.bin" "$retroarch_path/system/scph102b.bin"
@@ -73,7 +73,7 @@ exit_checkSaveState(){
     
   ra_last_game=`ls -t "${ra_savestate_path}/"*.auto | head -1`
 
-  if [ "$ra_last_game" == "" ]; then
+  if [ x"$ra_last_game" = x"" ]; then
     echo "[BLEEMSYNC](INFO) no auto save state exists"
     end=$(date +%s%N)
     echo "[BLEEMSYNC](PROFILE) RetroArch check for save state took: $(((end-start)/1000000))ms to execute"
@@ -83,7 +83,7 @@ exit_checkSaveState(){
   ra_last_game="${ra_last_game##*/}"          # Remove leading directories
   ra_last_game="${ra_last_game%.state.auto}"  # Remove trailing file extension .state.auto
 
-  if [ ! "$ra_last_game" == "$intercept_game_id" ]; then    
+  if [ ! "$ra_last_game" = "$intercept_game_id" ]; then    
     #  The last save state was for a different game, check if this disc belongs to the launching game
     #  If it does then a disc swap has occured, so update the game ids so the correct save state
     #  data is passed to ui_menu state is from a game which is different to the launched game"

--- a/Payload/bleemsync/etc/bleemsync/FUNC/0040_theme.funcs
+++ b/Payload/bleemsync/etc/bleemsync/FUNC/0040_theme.funcs
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 #
 #  Copyright 2019 ModMyClassic (https://modmyclassic.com/license)
 #
@@ -23,11 +23,12 @@
 
 overmount_existing() {
   IFS='\n'
-  for rel_file in find "$1" -type f -printf '%P\n'; do
+  while read -r rel_file; do
+    rel_file="${rel_file#$1/}"
     if [ -f "$2/${rel_file}" ]; then
       mount -o bind "$1/${rel_file}" "$2/${rel_file}"
     fi
-  done
+  done < <(find "$1" -type f)
   unset IFS
 }
 
@@ -52,10 +53,7 @@ select_UI_theme(){
   # Initial vars
   found_theme=0
   found_boot_files=0
-  found_font_files=0
-  found_image_files=0
   found_music_files=0
-  found_sound_files=0
 
   if [ "$selected_theme" != "stock" ] && [ -d "$themes_path/$selected_theme" ]; then
     # Set found theme var for log

--- a/Payload/bleemsync/etc/bleemsync/FUNC/0040_theme.funcs
+++ b/Payload/bleemsync/etc/bleemsync/FUNC/0040_theme.funcs
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 #
 #  Copyright 2019 ModMyClassic (https://modmyclassic.com/license)
 #
@@ -22,14 +22,7 @@
 ###############################################################################
 
 overmount_existing() {
-  IFS='\n'
-  while read -r rel_file; do
-    rel_file="${rel_file#$1/}"
-    if [ -f "$2/${rel_file}" ]; then
-      mount -o bind "$1/${rel_file}" "$2/${rel_file}"
-    fi
-  done < <(find "$1" -type f)
-  unset IFS
+  "$bleemsync_path/etc/bleemsync/SUP/scripts/overmount_existing" "$@"
 }
 
 select_UI_theme(){

--- a/Payload/bleemsync/etc/bleemsync/FUNC/0040_theme.funcs
+++ b/Payload/bleemsync/etc/bleemsync/FUNC/0040_theme.funcs
@@ -1,17 +1,17 @@
 #!/bin/sh
 #
 #  Copyright 2019 ModMyClassic (https://modmyclassic.com/license)
-#  
+#
 #  This program is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
 #  the Free Software Foundation, either version 3 of the License, or
 #  (at your option) any later version.
-#  
+#
 #  This program is distributed in the hope that it will be useful,
 #  but WITHOUT ANY WARRANTY; without even the implied warranty of
 #  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 #  GNU General Public License for more details.
-#  
+#
 #  You should have received a copy of the GNU General Public License
 #  along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #
@@ -20,6 +20,16 @@
 # BleemSync Function Library - Stock UI Themes
 # ModMyClassic.com / https://discordapp.com/invite/8gygsrw
 ###############################################################################
+
+overmount_existing() {
+  IFS='\n'
+  for rel_file in find "$1" -type f -printf '%P\n'; do
+    if [ -f "$2/${rel_file}" ]; then
+      mount -o bind "$1/${rel_file}" "$2/${rel_file}"
+    fi
+  done
+  unset IFS
+}
 
 select_UI_theme(){
   echo "[BLEEMSYNC](Executing) select_UI_theme()"
@@ -33,14 +43,12 @@ select_UI_theme(){
 
   # Set random theme if setting is set
   if [ "$random_theme_onload" = "1" ]; then
-    cd "$themes_path"
-    selected_theme=$(ls -d * | sort --random-sort | head -1)
-    cd "/home/root"
+    selected_theme=$(ls -d1 "$themes_path/"*/ | sort --random-sort | head -1 | xargs basename)
   fi
-  
+
   # Lower-case the theme variable incase it causes and issue
   selected_theme="$(echo $selected_theme | tr 'A-Z' 'a-z')"
-  
+
   # Initial vars
   found_theme=0
   found_boot_files=0
@@ -48,7 +56,7 @@ select_UI_theme(){
   found_image_files=0
   found_music_files=0
   found_sound_files=0
-  
+
   if [ "$selected_theme" != "stock" ] && [ -d "$themes_path/$selected_theme" ]; then
     # Set found theme var for log
     found_theme=1
@@ -62,41 +70,15 @@ select_UI_theme(){
         # if [ ${boot_file: -4} == ".wav" ]; then sounds_path="$themes_path/$selected_theme/boot"; found_boot_files=1; fi
       done
       cd "/home/root"
-    fi 2> /dev/null 
-    # Check for the font folder
-    if [ -d "$themes_path/$selected_theme/font" ]; then
-      cd "$themes_path/$selected_theme/font"
-      for font_file in $(find -iname \*.ttf | sed -e 's,^\./,,'); do
-        mount -o bind "$themes_path/$selected_theme/font/$font_file" "/usr/sony/share/data/font/$font_file"
-        found_font_files=1
-      done
-      cd "/home/root"
-    fi 2> /dev/null 
-    # Check for the images folder
-    if [ -d "$themes_path/$selected_theme/images" ]; then
-      cd "$themes_path/$selected_theme/images"
-      for image_file in $(find -iname \*.png | sed -e 's,^\./,,'); do
-        mount -o bind "$themes_path/$selected_theme/images/$image_file" "/usr/sony/share/data/images/$image_file"
-        found_image_files=1
-      done
-      cd "/home/root"
-    fi 2> /dev/null 
+    fi 2> /dev/null
+
     # Check for the music folder
     if [ -d "$themes_path/$selected_theme/music" ] && [ "$override_theme_music" = "0" ]; then
-      cd "$themes_path/$selected_theme/music"
-      for music_file in $(find -iname \*.wav | sed -e 's,^\./,,'); do
-        if [ ${music_file: -4} == ".wav" ]; then mount -o bind "$themes_path/$selected_theme/music" "$sounds_path/music"; found_music_files=1; fi
-      done
-    fi 2> /dev/null 
-    # Check for the sounds folder
-    if [ -d "$themes_path/$selected_theme/sounds" ]; then
-      cd "$themes_path/$selected_theme/sounds"
-      for sound_file in $(find -iname \*.wav | sed -e 's,^\./,,'); do
-        mount -o bind "$themes_path/$selected_theme/sounds/$sound_file" "/usr/sony/share/data/sounds/$sound_file"
-        found_sound_files=1
-      done
-      cd "/home/root"
-    fi 2> /dev/null     
+      found_music_files=1
+      overmount_existing "$themes_path/$selected_theme/music" "$sounds_path/music"
+    fi
+
+    overmount_existing "$themes_path/$selected_theme" /usr/sony/share/data
   fi
   # log if stuff is found or not
   if [ "$found_theme" == "1" ]; then
@@ -109,25 +91,10 @@ select_UI_theme(){
   else
     echo "[BLEEMSYNC](INFO)(theme) mounting stock boot menu files"
   fi
-  if [ "$found_font_files" == "1" ]; then
-    echo "[BLEEMSYNC](INFO)(theme) mounting available font files"
-  else
-    echo "[BLEEMSYNC](INFO)(theme) mounting stock font files"
-  fi
-  if [ "$found_image_files" == "1" ]; then
-    echo "[BLEEMSYNC](INFO)(theme) mounting available image files"
-  else
-    echo "[BLEEMSYNC](INFO)(theme) mounting stock image files"
-  fi
   if [ "$found_music_files" == "1" ]; then
     echo "[BLEEMSYNC](INFO)(theme) mounting available music files"
   else
     echo "[BLEEMSYNC](INFO)(theme) mounting stock music files"
-  fi
-  if [ "$found_sound_files" == "1" ]; then
-    echo "[BLEEMSYNC](INFO)(theme) mounting available sound files"
-  else
-    echo "[BLEEMSYNC](INFO)(theme) mounting stock sound files"
   fi
   echo 0 > /sys/class/leds/red/brightness
   end=$(date +%s%N)

--- a/Payload/bleemsync/etc/bleemsync/FUNC/0050_bleemsync.funcs
+++ b/Payload/bleemsync/etc/bleemsync/FUNC/0050_bleemsync.funcs
@@ -48,14 +48,17 @@ launch_BootMenu(){
 
 launch_StockUI(){
   echo "[BLEEMSYNC](INFO) launching stock ui"
-  echo 0 > /data/power/disable
-  cd "/data/AppData/sony/pcsx"
-  export PCSX_ESC_KEY=2
- 
   # Remove power file flags
   rm -f "/data/power/prepare_suspend" "/data/power/apps_okay"
- 
+  # Fix for last selected game issue. If not in place user may experience ui issue
+  sed -i "s/iUiUserSettingLastSelectGameCursorPos=.*/iUiUserSettingLastSelectGameCursorPos=0/" /data/AppData/sony/ui/user.pre
+
+  cd "/data/AppData/sony/pcsx"
+  export PCSX_ESC_KEY=2
   /usr/sony/bin/ui_menu --power-off-enable &> "$runtime_log_path/ui_menu.log"
+
+  # Reset last selected game in case user does not use BleemSync on next boot
+  sed -i "s/iUiUserSettingLastSelectGameCursorPos=.*/iUiUserSettingLastSelectGameCursorPos=0/" /data/AppData/sony/ui/user.pre
 }
 ###############################################################################
 
@@ -67,56 +70,12 @@ execute_bleemsync_func(){
 #-----------------------------------------------------------------------------#
   start=$(date +%s%N)
 
-  #Run on console bleemsync (This will be replaced in 1.0)
-  if [ -f "$mountpoint/system/bleemsync/BleemSync" ]
-  then
-    cd "$mountpoint/system/bleemsync"
-    chmod +x "BleemSync"
-    ./BleemSync
-    cd "/home/root"
-  fi
-
-  end=$(date +%s%N)
-  echo "[BLEEMSYNC](PROFILE) BleemSync DB processing took: $(((end-start)/1000000))ms to execute"
-#-----------------------------------------------------------------------------#
-  start=$(date +%s%N)
-
-  # Build external directory structure
-  mkdir -p "$mountpoint/system/bios"
-  mkdir -p "$mountpoint/system/preferences/system"
-  mkdir -p "$mountpoint/system/preferences/user"
-  mkdir -p "$mountpoint/system/preferences/autodimmer"
-  mkdir -p "$mountpoint/system/databases"
-  mkdir -p "$mountpoint/system/region"
-  mkdir -p "$mountpoint/system/ui"
-
-  # Copy the bios files
-  [ ! -f "$mountpoint/system/bios/romw.bin" ] && cp -fr "/gaadata/system/bios/"* "$mountpoint/system/bios"
-  # Copy the regional.pre
-  [ ! -f "$mountpoint/system/preferences/system/regional.pre" ] && cp -f "/gaadata/preferences/"* "$mountpoint/system/preferences/system"
-  # Copy out the user.pre
-  [ ! -f "$mountpoint/system/preferences/user/user.pre" ] && cp -f "/data/AppData/sony/ui/"* "$mountpoint/system/preferences/user"
-  # Copy out the auto dimming config
-  [ ! -f "$mountpoint/system/preferences/autodimmer/config.cnf" ] && cp -f "/data/AppData/sony/auto_dimmer/"* "$mountpoint/system/preferences/autodimmer"
-  # Copy out the region info
-  [ ! -f "$mountpoint/system/region/REGION" ] && cp -f "/gaadata/geninfo/"* "$mountpoint/system/region"
-  # Copy ui error log
-  [ ! -f "$mountpoint/system/ui/error.log" ] && cp -f "/data/sony/ui/"* "$mountpoint/system/ui"
-  sync
-
-  end=$(date +%s%N)
-  echo "[BLEEMSYNC](PROFILE) BleemSync data processing took: $(((end-start)/1000000))ms to execute"
-#-----------------------------------------------------------------------------#
-  start=$(date +%s%N)
-
   # Unmount partitons and create tmpfs - Shut system down on failure
   MOUNT_FAIL=0
-  umount /data || MOUNT_FAIL=1
-  umount /gaadata || MOUNT_FAIL=1
   # Create gaadata and data folders in tmp then mount over original folders
-  mkdir -p "/var/volatile/gaadatatmp" "/var/volatile/datatmp"
-  mount -o bind "/var/volatile/gaadatatmp" "/gaadata" || MOUNT_FAIL=1
-  mount -o bind "/var/volatile/datatmp" "/data" || MOUNT_FAIL=1
+  VOL_GAADATA="/var/volatile/gaadatatmp"
+  VOL_DATAPCSX="/var/volatile/datatmp"
+  mkdir -p "${VOL_GAADATA}" "${VOL_DATAPCSX}"
   mount -o bind "$bleemsync_path/etc/bleemsync/SUP/scripts/20-joystick.rules" "/etc/udev/rules.d/20-joystick.rules" || MOUNT_FAIL=1
   mount -o bind "$bleemsync_path/etc/bleemsync/SUP/binaries/pcsx" "/usr/sony/bin/pcsx" || MOUNT_FAIL=1
 
@@ -136,45 +95,26 @@ execute_bleemsync_func(){
   start=$(date +%s%N)
 
   # Create gaadata on tmpfs
-  mkdir -p "/var/volatile/gaadatatmp/system/"
   if [ "$link_EMMC_and_USB" = "1" ]; then
-    mkdir -p "/var/volatile/gaadatatmp/databases/"
-    cp -f "$mountpoint/system/databases/regional.db" "/var/volatile/gaadatatmp/databases/"
+    mkdir -p "${VOL_GAADATA}/databases/"
+    cp -f "$mountpoint/system/databases/regional.db" "${VOL_GAADATA}/databases/"
   else
-    ln -s "$mountpoint/system/databases" "/var/volatile/gaadatatmp/"
+    ln -s "$mountpoint/system/databases" "${VOL_GAADATA}"
   fi
-  ln -s "$mountpoint/system/region" "/var/volatile/gaadatatmp/geninfo"
-  ln -s "$mountpoint/system/bios" "/var/volatile/gaadatatmp/system/bios"
-  ln -s "$mountpoint/system/preferences/system" "/var/volatile/gaadatatmp/preferences"
+  ln -s /gaadata/geninfo "${VOL_GAADATA}"
+  ln -s /gaadata/preferences "${VOL_GAADATA}"
+  ln -s /gaadata/system "${VOL_GAADATA}"
 
   # Create data on tmpfs
-  mkdir -p "/var/volatile/datatmp/sony/sgmo" "/var/volatile/datatmp/AppData/sony"
-  # ln -s "/tmp/diag" "/tmp/datatmp/sony/sgmo/diag"
-  ln -s "/dev/shm/power" "/var/volatile/datatmp/power"
-  ln -s "$mountpoint/system/ui" "/var/volatile/datatmp/sony/ui"
-  ln -s "$mountpoint/system/preferences/user" "/var/volatile/datatmp/AppData/sony/ui"
-  ln -s "$mountpoint/system/preferences/autodimmer" "/var/volatile/datatmp/AppData/sony/auto_dimmer"
-  cp -fr "/usr/sony/share/recovery/AppData/sony/pcsx" "/var/volatile/datatmp/AppData/sony/pcsx"
+  ln -s /gaadata/system/bios "${VOL_DATAPCSX}"
+  ln -s /usr/sony/bin/plugins "${VOL_DATAPCSX}"
 
-  PrevIFS="$IFS"
-  IFS=$'\t\r\n'
-  i=1
-  for game in `ls -d -v -1 $mountpoint/games/**`
-  do
-    if [ -d "${game}" ]; then
-      game_dir="${game}"
-      [ -d "${game_dir}/GameData" ] && game_dir="${game}/GameData"
-      ln -s "${game_dir}" /var/volatile/gaadatatmp/$i
-      rm -rf /var/volatile/datatmp/AppData/sony/pcsx/$i
-      ln -s "${game_dir}" /var/volatile/datatmp/AppData/sony/pcsx/$i
-      i=$((i+1))
-    fi
+  # Link games on /media
+  for game in "${mountpoint}/games/"*/; do
+    ln -s "${game}" "${VOL_GAADATA}"
+    ln -s "${game}" "${VOL_DATAPCSX}"
   done
-  IFS="$PrevIFS"
-  
-  ln -s "$mountpoint/system/bios" "/var/volatile/datatmp/AppData/sony/pcsx/bios"
-  ln -s "/usr/sony/bin/plugins" "/var/volatile/datatmp/AppData/sony/pcsx/plugins"
-  
+
   # Force intercept to allow launching custom scripts from stock UI
   mount -o bind "$bleemsync_path/etc/bleemsync/SUP/scripts/system.pre" "/usr/sony/share/data/preferences/system.pre"
   cp "$bleemsync_path/etc/bleemsync/SUP/scripts/intercept" "/tmp/intercept"
@@ -186,69 +126,51 @@ execute_bleemsync_func(){
   # Unite EMMC and MEDIA games and databases
   if [ "$link_EMMC_and_USB" = "1" ]; then
     start=$(date +%s%N)
-    [ -d "/var/volatile/emmc_gaadata" ] && umount "/var/volatile/emmc_gaadata" && rm -fr "/var/volatile/emmc_gaadata"
-    [ -d "/var/volatile/emmc_data" ] && umount "/var/volatile/emmc_data" && rm -fr "/var/volatile/emmc_data"
-    mkdir -p "/var/volatile/emmc_gaadata" && mount -o ro "/dev/mapper/gaadata" "/var/volatile/emmc_gaadata/"
-    mkdir -p "/var/volatile/emmc_data" && mount "/dev/mmcblk0p10" "/var/volatile/emmc_data/"
 
-    emmc_gaadata_count=$(ls "/var/volatile/emmc_gaadata" | grep '^[0-9]\+$' | wc -l)
-    media_gaadata_count=$(ls "/var/volatile/gaadatatmp" | grep '^[0-9]\+$' | wc -l)
-    i=1
+    emmc_gaadata_count=$(ls -d1 /gaadata/*/ | grep '^[0-9]\+$' | wc -l)
+    media_gaadata_count=$(ls -d1 "${mountpoint}/games/"*/ | grep '^[0-9]\+$' | wc -l)
 
-    $bleemsync_path/bin/sqlite3 "/var/volatile/emmc_gaadata/databases/regional.db" -cmd ".output /tmp/emmc.sql" ".dump" ".quit"
-    [ -f "/tmp/join.sql" ] && rm -f "/tmp/join.sql" && touch "/tmp/join.sql"
+    "$bleemsync_path/bin/sqlite3" "/gaadata/databases/regional.db" -cmd ".output /tmp/emmc.sql" ".dump" ".quit"
+    rm "/tmp/join.sql"
 
-    echo "BEGIN TRANSACTION;" >> "/tmp/join.sql"
-    while true; do
-      [ "$i" = "$(( emmc_gaadata_count + 1))" ] && break
-      ln -s "/var/volatile/emmc_gaadata/$i" "/var/volatile/gaadatatmp/$(( media_gaadata_count + i ))"
-      rm -rf "/var/volatile/datatmp/AppData/sony/pcsx/$(( media_gaadata_count + i ))"
-      ln -s "/var/volatile/emmc_data/AppData/sony/pcsx/$i" "/var/volatile/datatmp/AppData/sony/pcsx/$(( media_gaadata_count + i ))"
+    echo "BEGIN TRANSACTION;" > "/tmp/join.sql"
+    for i in $(seq 1 $emmc_gaadata_count); do
+      ln -s "/gaadata/$i/" "${VOL_GAADATA}/$(( media_gaadata_count + i ))"
+      ln -s "/data/AppData/sony/pcsx/$i/" "${VOL_DATAPCSX}/$(( media_gaadata_count + i ))"
       echo $(grep "GAME VALUES($i," "/tmp/emmc.sql" | awk -v newindex=$(( media_gaadata_count + i )) -F "," '{ print "INSERT INTO GAME VALUES("newindex","$2","$3","$4","$5","$6","$7","$8","$9 }') >> "/tmp/join.sql"
       echo $(grep "DISC VALUES($i," "/tmp/emmc.sql" | awk -v newindex=$(( media_gaadata_count + i )) -F "," '{ print "INSERT INTO DISC VALUES(null,"newindex","$2","$3 }') >> "/tmp/join.sql"
-      i=$(( i + 1 ))
     done
     echo "COMMIT;" >> "/tmp/join.sql"
 
     sed -i -e 's/;,/;/g' "/tmp/join.sql" #Required cleanup because of potential dirty characters in SONY stock SQLite DB
 
-    $bleemsync_path/bin/sqlite3 "/var/volatile/gaadatatmp/databases/regional.db" -cmd ".read /tmp/join.sql" ".quit"
+    "$bleemsync_path/bin/sqlite3" "${VOL_GAADATA}/databases/regional.db" -cmd ".read /tmp/join.sql" ".quit"
 
     if [ "$link_alphabeticalise" = "1" ]; then
       echo "create table new as select * from GAME order by GAME_TITLE_STRING; drop table GAME; create table GAME as select * from new order by GAME_TITLE_STRING; drop table new" \
-      | $bleemsync_path/bin/sqlite3 "/var/volatile/gaadatatmp/databases/regional.db"
+      | "$bleemsync_path/bin/sqlite3" "${VOL_GAADATA}/databases/regional.db"
     fi
 
     end=$(date +%s%N)
     echo "[BLEEMSYNC](PROFILE) BleemSync EMMC + USB dyna link took: $(((end-start)/1000000))ms to execute"
-  else
-    [ -d "/var/volatile/emmc_gaadata" ] && umount "/var/volatile/emmc_gaadata" && rm -fr "/var/volatile/emmc_gaadata"
-    [ -d "/var/volatile/emmc_data" ] && umount "/var/volatile/emmc_data" && rm -fr "/var/volatile/emmc_data"
-    mkdir -p "/var/volatile/emmc_gaadata" && mount -o ro "/dev/mapper/gaadata" "/var/volatile/emmc_gaadata/"
-    mkdir -p "/var/volatile/emmc_data" && mount "/dev/mmcblk0p10" "/var/volatile/emmc_data/"
   fi
 #-----------------------------------------------------------------------------#
   start=$(date +%s%N)
-  # Fix for last selected game issue. If not in place user may experience ui issue
-  sed -i "s/iUiUserSettingLastSelectGameCursorPos.*/iUiUserSettingLastSelectGameCursorPos=0/" "/var/volatile/datatmp/AppData/sony/ui/user.pre"
 
   # Reload and apply udev rules that were overmounted above
   # Allows both controllers to be detected through a USB hub
   udevadm control --reload-rules
   udevadm trigger
 
-  # Default pcsx.cfg
-  for game in $mountpoint/games/*
-  do
-    if [ -d "${game}" ]; then
-      game_dir="${game}"
-      [ -d "${game_dir}/GameData" ] && game_dir="${game}/GameData"
-      [ ! -f "${game_dir}/.pcsx/pcsx.cfg" ] && mkdir -p "${game_dir}/.pcsx" && cp -f "$mountpoint/system/defaults/pcsx.cfg" "${game_dir}/.pcsx/pcsx.cfg"
-	  mkdir -p "${game_dir}/.pcsx/cfg" "${game_dir}/.pcsx/cheats" "${game_dir}/.pcsx/memcards" "${game_dir}/.pcsx/patches" "${game_dir}/.pcsx/plugins" "${game_dir}/.pcsx/screenshots" "${game_dir}/.pcsx/sstates"
+  # Migrate GameData contents and copy default pcsx.cfg if not present
+  for game in "${mountpoint}/games/"*/; do
+    if [ -d "${game}/GameData" ]; then
+      mv -f "${game}/GameData/"* "${game}/GameData/".[!.]* "${game}/"
+      rmdir "${game}/GameData"
     fi
+    mkdir -p "${game}/.pcsx"
+    [ ! -f "${game}/.pcsx" ] && cp "$mountpoint/system/defaults/pcsx.cfg" "${game}/.pcsx/pcsx.cfg"
   done
-
-  cd "/home/root"
 
   end=$(date +%s%N)
   echo "[BLEEMSYNC](PROFILE) BleemSync general fixing took: $(((end-start)/1000000))ms to execute"
@@ -257,22 +179,18 @@ execute_bleemsync_func(){
   if [ "$boot_disable_health" = "1" ]; then
     start=$(date +%s%N)
     echo "[BLEEMSYNC](INFO) attempting to patch out H+S statement"
-    PATCH_FAIL=0
     PATCH_DIR="/var/volatile/health_patch"
-    PATCH_BIN="$PATCH_DIR/patch.bin"
-    PATCH_TARGET="/usr/sony/bin/ui_menu"
-    PATCH_WORKING="$PATCH_DIR/ui_menu"
+    PATCH_TARGET=/usr/sony/bin/ui_menu
+    PATCH_WORKING="${PATCH_DIR}/ui_menu"
 
     # Perform patching
-    mkdir -p "$PATCH_DIR"
-    cp -f "$PATCH_TARGET" "$PATCH_WORKING"
-    echo -n -e '\xb8\x0c\x00\x06\x03\x58\xbe' > "$PATCH_BIN"
-    dd bs=1 if="$PATCH_BIN" skip=0 of="$PATCH_WORKING" seek=28084 count=3 conv=notrunc
-    dd bs=1 if="$PATCH_BIN" skip=3 of="$PATCH_WORKING" seek=28120 count=2 conv=notrunc
-    dd bs=1 if="$PATCH_BIN" skip=5 of="$PATCH_WORKING" seek=28712 count=2 conv=notrunc
-    rm -f "$PATCH_BIN"
-    mount -o bind "$PATCH_WORKING" "$PATCH_TARGET" || PATCH_FAIL=1
-    if [ "$PATCH_FAIL" = "0" ]; then
+    mkdir -p "${PATCH_DIR}"
+    cp "${PATCH_TARGET}" "${PATCH_WORKING}"
+    echo -ne '\xb8\x0c\x00' | dd bs=1 of="${PATCH_WORKING}" seek=28084 conv=notrunc
+    echo -ne '\x06\x03' | dd bs=1 of="${PATCH_WORKING}" seek=28120 conv=notrunc
+    echo -ne '\x58\xbe' | dd bs=1 of="${PATCH_WORKING}" seek=28712 conv=notrunc
+    mount -o bind "${PATCH_WORKING}" "${PATCH_TARGET}"
+    if [ "$?" -eq "0" ]; then
       echo "[BLEEMSYNC](INFO) patched out H+S statement"
     else
       echo "[BLEEMSYNC](FAIL) failed to patch out H+S statement, continuing anyway..."
@@ -290,11 +208,10 @@ execute_bleemsync_func(){
   start=$(date +%s%N)
   #Cleanup before starting main user applications
   rm -rf "/tmp/systemd"*
-  rm -rf "/tmp/diag"
+  rm -rf "/tmp/diag/"*
   rm -rf "/tmp/"*".sql"
 
   killall -s KILL sdl_display &> /dev/null
-  booted=0
 
   end=$(date +%s%N)
   echo "[BLEEMSYNC](PROFILE) BleemSync pre run cleanup took: $(((end-start)/1000000))ms to execute"
@@ -303,7 +220,7 @@ execute_bleemsync_func(){
   boot_command="launch_StockUI"
   [ "$boot_target_stock_BM" = "1" ] && boot_command="launch_BootMenu"
   [ "$boot_target_stock_RA" = "1" ] && boot_command="launch_retroarch"
-  
+
   while [ $boot_command != "quit" ]; do
     $boot_command
     [ -f /tmp/launchfilecommand ] && boot_command=$(cat /tmp/launchfilecommand) || boot_command="quit"
@@ -317,7 +234,6 @@ execute_bleemsync_func(){
       sleep 9999
     done
   else
-    rm -rf "/tmp/ra_cache"
     sync
     echo "[BLEEMSYNC](Executed) execute_bleemsync_func()"
     reboot

--- a/Payload/bleemsync/etc/bleemsync/FUNC/0050_bleemsync.funcs
+++ b/Payload/bleemsync/etc/bleemsync/FUNC/0050_bleemsync.funcs
@@ -127,18 +127,17 @@ execute_bleemsync_func(){
   if [ "$link_EMMC_and_USB" = "1" ]; then
     start=$(date +%s%N)
 
-    emmc_gaadata_count=$(ls -d1 /gaadata/*/ | grep '^[0-9]\+$' | wc -l)
-    media_gaadata_count=$(ls -d1 "${mountpoint}/games/"*/ | grep '^[0-9]\+$' | wc -l)
+    emmc_gaadata_count=$(ls -d1 /gaadata/*/ | grep '/[0-9]\+/$' | wc -l)
+    media_gaadata_count=$(ls -d1 "${mountpoint}/games/"*/ | grep '/[0-9]\+/$' | wc -l)
 
     "$bleemsync_path/bin/sqlite3" "/gaadata/databases/regional.db" -cmd ".output /tmp/emmc.sql" ".dump" ".quit"
-    rm "/tmp/join.sql"
 
     echo "BEGIN TRANSACTION;" > "/tmp/join.sql"
     for i in $(seq 1 $emmc_gaadata_count); do
       ln -s "/gaadata/$i/" "${VOL_GAADATA}/$(( media_gaadata_count + i ))"
       ln -s "/data/AppData/sony/pcsx/$i/" "${VOL_DATAPCSX}/$(( media_gaadata_count + i ))"
       echo $(grep "GAME VALUES($i," "/tmp/emmc.sql" | awk -v newindex=$(( media_gaadata_count + i )) -F "," '{ print "INSERT INTO GAME VALUES("newindex","$2","$3","$4","$5","$6","$7","$8","$9 }') >> "/tmp/join.sql"
-      echo $(grep "DISC VALUES($i," "/tmp/emmc.sql" | awk -v newindex=$(( media_gaadata_count + i )) -F "," '{ print "INSERT INTO DISC VALUES(null,"newindex","$2","$3 }') >> "/tmp/join.sql"
+      echo $(grep "DISC VALUES($i," "/tmp/emmc.sql" | awk -v newindex=$(( media_gaadata_count + i )) -F "," '{ print "INSERT INTO DISC VALUES("newindex","$2","$3 }') >> "/tmp/join.sql"
     done
     echo "COMMIT;" >> "/tmp/join.sql"
 
@@ -154,6 +153,9 @@ execute_bleemsync_func(){
     end=$(date +%s%N)
     echo "[BLEEMSYNC](PROFILE) BleemSync EMMC + USB dyna link took: $(((end-start)/1000000))ms to execute"
   fi
+
+  # Overmount the stock DB now that we're done using it
+  mount -o bind "${VOL_GAADATA}/databases/regional.db" /gaadata/databases/regional.db
 #-----------------------------------------------------------------------------#
   start=$(date +%s%N)
 
@@ -169,7 +171,7 @@ execute_bleemsync_func(){
       rmdir "${game}/GameData"
     fi
     mkdir -p "${game}/.pcsx"
-    [ ! -f "${game}/.pcsx" ] && cp "$mountpoint/system/defaults/pcsx.cfg" "${game}/.pcsx/pcsx.cfg"
+    [ ! -f "${game}/.pcsx/pcsx.cfg" ] && cp "$mountpoint/system/defaults/pcsx.cfg" "${game}/.pcsx/pcsx.cfg"
   done
 
   end=$(date +%s%N)
@@ -226,6 +228,14 @@ execute_bleemsync_func(){
     [ -f /tmp/launchfilecommand ] && boot_command=$(cat /tmp/launchfilecommand) || boot_command="quit"
     rm -f /tmp/launchfilecommand
   done
+
+  # Debug cleanup
+  umount /etc/udev/rules.d/20-joystick.rules
+  umount /usr/sony/bin/pcsx
+  if [ "$boot_disable_health" = "1" ]; then umount /usr/sony/bin/ui_menu; fi
+  umount /gaadata/databases/regional.db
+  umount /usr/sony/share/data/preferences/system.pre
+  rm -r "${VOL_GAADATA}" "${VOL_DATAPCSX}" /var/volatile/bleemsync.cfg
 
 #-----------------------------------------------------------------------------#
   #Cleanup and shutdown (If active telnet session don't shutdown console.)

--- a/Payload/bleemsync/etc/bleemsync/FUNC/0050_bleemsync.funcs
+++ b/Payload/bleemsync/etc/bleemsync/FUNC/0050_bleemsync.funcs
@@ -1,4 +1,21 @@
 #!/bin/sh
+#
+#  Copyright 2019 ModMyClassic (https://modmyclassic.com/license)
+#
+#  This program is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+
 ###############################################################################
 # BleemSync Function Library - BleemSync
 # ModMyClassic.com / https://discordapp.com/invite/8gygsrw

--- a/Payload/bleemsync/etc/bleemsync/SUP/scripts/intercept
+++ b/Payload/bleemsync/etc/bleemsync/SUP/scripts/intercept
@@ -1,17 +1,17 @@
 #!/bin/sh
 #
 #  Copyright 2019 ModMyClassic (https://modmyclassic.com/license)
-#  
+#
 #  This program is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
 #  the Free Software Foundation, either version 3 of the License, or
 #  (at your option) any later version.
-#  
+#
 #  This program is distributed in the hope that it will be useful,
 #  but WITHOUT ANY WARRANTY; without even the implied warranty of
 #  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 #  GNU General Public License for more details.
-#  
+#
 #  You should have received a copy of the GNU General Public License
 #  along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #
@@ -24,7 +24,7 @@
 ### CHECK FOR LAUNCH SCRIPT ###################################################
 # If launch script exists run it instead of pcsx/RA
 if [ -f "/data/AppData/sony/title/launch.sh" ]; then
-  exec "/data/AppData/sony/title/launch.sh" 
+  exec "/data/AppData/sony/title/launch.sh"
   # Shouldn't get to here
   exit 1
 fi
@@ -45,12 +45,12 @@ intercept_game_ext=""
 intercept_game_alternative_path=""
 intercept_save_state=false
 intercept_file_formats=(    # alternative PCSX ReARMed game formats
-    "m3u"
-    "pbp"
-    "img"
-    "mdf"
-    "toc"
-    "cbn" 
+  "m3u"
+  "pbp"
+  "img"
+  "mdf"
+  "toc"
+  "cbn"
 )
 
 ### START INTERCEPT SCRIPT ####################################################
@@ -60,10 +60,10 @@ intercept_file_formats=(    # alternative PCSX ReARMed game formats
 ###############################################################################
 echo "[INTERCEPT](INFO) Starting PS Classic Intercept"
 if [ "$#" -ge 1 ]; then
-    echo "[INTERCEPT](INFO) There are $# parameters:"
-    echo "[INTERCEPT](INFO) $*"
+  echo "[INTERCEPT](INFO) There are $# parameters:"
+  echo "[INTERCEPT](INFO) $*"
 else
-    echo "[INTERCEPT](INFO) There are no parameters"
+  echo "[INTERCEPT](INFO) There are no parameters"
 fi
 
 echo "[INTERCEPT](INFO) The current working directory: $PWD"
@@ -74,61 +74,61 @@ found_cdfile=false
 # Loop through each argument to pull out information relating to which game is being loaded
 # and whether this is a Save State load
 start_arg=$(date +%s%N)
-for arg in "$@" 
+for arg in "$@"
 do
 
-    if [ "$found_cdfile" = true ]; then
-        
-        intercept_game_path="$arg"
-        echo "[INTERCEPT](INFO) Game full path: ${intercept_game_path}"
-        intercept_game_dir="${arg%/*}/"
-        echo "[INTERCEPT](INFO) Game directory: ${intercept_game_dir}"
-        intercept_game_id="${arg##*/}"
-        intercept_game_id="${intercept_game_id%.*}"
-        echo "[INTERCEPT](INFO) Game ID: $intercept_game_id"
-        intercept_game_ext="${arg##*.}"
-        echo "[INTERCEPT](INFO) Game extension: $intercept_game_ext"
+  if [ "$found_cdfile" = true ]; then
 
-        # Check if the game exists in an alternative format
-        # The game path always has .cue appened to the BASENAME field of the DISC table in regional.db
-        # EXCEPT when the game is launched from a Save State. In this case the Game Path is determined from
-        # the first line of filename.txt.res in the games PCSX data directory (ie. /data/AppData/sony/pcsx/1/.pcsx/filename.txt.res)
-        if [ "$intercept_save_state" = false ]; then
-            
-            start_alt=$(date +%s%N)
-            for f in "${intercept_file_formats[@]}"; do
-                intercept_game_alternative_path="${arg%.cue}.${f}"
-                if [ -f "$intercept_game_alternative_path" ]; then
-                    echo "[INTERCEPT](INFO) Alternative game format exists (${f}), this will be used instead of the .cue"
-                    arg="$intercept_game_alternative_path"
-                    intercept_game_path="$arg"
-                    intercept_game_ext="${f}"
-                    echo "[INTERCEPT](INFO) New Game full path: ${intercept_game_path}"
-                    echo "[INTERCEPT](INFO) New Game extension: ${intercept_game_ext}"
-                    break
-                fi
-            done
-            end_alt=$(date +%s%N)
-            echo "[INTERCEPT](PROFILE) finding alternative game formats took: $(((end_alt-start_alt)/1000000))ms to execute"
+    intercept_game_path="$arg"
+    echo "[INTERCEPT](INFO) Game full path: ${intercept_game_path}"
+    intercept_game_dir="${arg%/*}/"
+    echo "[INTERCEPT](INFO) Game directory: ${intercept_game_dir}"
+    intercept_game_id="${arg##*/}"
+    intercept_game_id="${intercept_game_id%.*}"
+    echo "[INTERCEPT](INFO) Game ID: $intercept_game_id"
+    intercept_game_ext="${arg##*.}"
+    echo "[INTERCEPT](INFO) Game extension: $intercept_game_ext"
+
+    # Check if the game exists in an alternative format
+    # The game path always has .cue appened to the BASENAME field of the DISC table in regional.db
+    # EXCEPT when the game is launched from a Save State. In this case the Game Path is determined from
+    # the first line of filename.txt.res in the games PCSX data directory (ie. /data/AppData/sony/pcsx/1/.pcsx/filename.txt.res)
+    if [ "$intercept_save_state" = false ]; then
+
+      start_alt=$(date +%s%N)
+      for f in "${intercept_file_formats[@]}"; do
+        intercept_game_alternative_path="${arg%.cue}.${f}"
+        if [ -f "$intercept_game_alternative_path" ]; then
+          echo "[INTERCEPT](INFO) Alternative game format exists (${f}), this will be used instead of the .cue"
+          arg="$intercept_game_alternative_path"
+          intercept_game_path="$arg"
+          intercept_game_ext="${f}"
+          echo "[INTERCEPT](INFO) New Game full path: ${intercept_game_path}"
+          echo "[INTERCEPT](INFO) New Game extension: ${intercept_game_ext}"
+          break
         fi
-        found_cdfile=false
-        continue
+      done
+      end_alt=$(date +%s%N)
+      echo "[INTERCEPT](PROFILE) finding alternative game formats took: $(((end_alt-start_alt)/1000000))ms to execute"
     fi
+    found_cdfile=false
+    continue
+  fi
 
-    case $arg in 
-        -cdfile)
-            found_cdfile=true
-            continue
-            ;;
+  case $arg in
+    -cdfile)
+      found_cdfile=true
+      continue
+      ;;
 
-       -load)
-            echo "[INTERCEPT](INFO) This is a Save State load"
-            intercept_save_state=true
-            ;;
-    esac
+     -load)
+      echo "[INTERCEPT](INFO) This is a Save State load"
+      intercept_save_state=true
+      ;;
+  esac
 
-    #   Build the new parameters for PCSX
-    intercept_command="${intercept_command} ${arg}"
+  #   Build the new parameters for PCSX
+  intercept_command="${intercept_command} ${arg}"
 done
 end_arg=$(date +%s%N)
 echo "[INTERCEPT](PROFILE) extracting arguments took: $(((end_arg-start_arg)/1000000))ms to execute"
@@ -136,13 +136,13 @@ echo "[INTERCEPT](PROFILE) extracting arguments took: $(((end_arg-start_arg)/100
 
 if [ "$launch_ra_from_stock_UI" = "1" ]; then
 
-    echo "[INTERCEPT](INFO) RetroArch is enabled as the emulator"
-    end=$(date +%s%N)
-    echo "[INTERCEPT](PROFILE) up to launching RetroArch took: $(((end-start)/1000000))ms to execute"
-    link_ra_memory_cards
-    launch_retroarch_from_StockUI
-    exit_checkSaveState
-    exit 0
+  echo "[INTERCEPT](INFO) RetroArch is enabled as the emulator"
+  end=$(date +%s%N)
+  echo "[INTERCEPT](PROFILE) up to launching RetroArch took: $(((end-start)/1000000))ms to execute"
+  link_ra_memory_cards
+  launch_retroarch_from_StockUI
+  exit_checkSaveState
+  exit 0
 
 fi
 

--- a/Payload/bleemsync/etc/bleemsync/SUP/scripts/overmount_existing
+++ b/Payload/bleemsync/etc/bleemsync/SUP/scripts/overmount_existing
@@ -1,17 +1,17 @@
 #!/bin/bash
 #
 #  Copyright 2019 ModMyClassic (https://modmyclassic.com/license)
-#  
+#
 #  This program is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
 #  the Free Software Foundation, either version 3 of the License, or
 #  (at your option) any later version.
-#  
+#
 #  This program is distributed in the hope that it will be useful,
 #  but WITHOUT ANY WARRANTY; without even the implied warranty of
 #  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 #  GNU General Public License for more details.
-#  
+#
 #  You should have received a copy of the GNU General Public License
 #  along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #

--- a/Payload/bleemsync/etc/bleemsync/SUP/scripts/overmount_existing
+++ b/Payload/bleemsync/etc/bleemsync/SUP/scripts/overmount_existing
@@ -23,9 +23,8 @@
 
 IFS='\n'
 while read -r rel_file; do
-    rel_file="${rel_file#$1/}"
-    if [ -f "$2/${rel_file}" ]; then
-        echo "Binding $1/${rel_file} over $2/${rel_file}"
-        mount -o bind "$1/${rel_file}" "$2/${rel_file}"
-    fi
+  rel_file="${rel_file#$1/}"
+  if [ -f "$2/${rel_file}" ]; then
+    mount -o bind "$1/${rel_file}" "$2/${rel_file}"
+  fi
 done < <(find "$1" -type f)

--- a/Payload/bleemsync/etc/bleemsync/SUP/scripts/overmount_existing
+++ b/Payload/bleemsync/etc/bleemsync/SUP/scripts/overmount_existing
@@ -1,0 +1,31 @@
+#!/bin/bash
+#
+#  Copyright 2019 ModMyClassic (https://modmyclassic.com/license)
+#  
+#  This program is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#  
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#  
+#  You should have received a copy of the GNU General Public License
+#  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+
+###############################################################################
+# Recursive Existing Files Overmount Script
+# ModMyClassic.com / https://discordapp.com/invite/8gygsrw
+###############################################################################
+
+IFS='\n'
+while read -r rel_file; do
+    rel_file="${rel_file#$1/}"
+    if [ -f "$2/${rel_file}" ]; then
+        echo "Binding $1/${rel_file} over $2/${rel_file}"
+        mount -o bind "$1/${rel_file}" "$2/${rel_file}"
+    fi
+done < <(find "$1" -type f)

--- a/Payload/bleemsync/etc/bleemsync/SUP/scripts/system.pre
+++ b/Payload/bleemsync/etc/bleemsync/SUP/scripts/system.pre
@@ -1,1 +1,3 @@
 sPcsxExecPath=/tmp/intercept
+sPcsxGameImageOriginPath=/var/volatile/gaadatatmp/
+sPcsxDataOriginPath=/var/volatile/datatmp/


### PR DESCRIPTION
Here's some spring cleaning for you. The most notable change is discarding all the `/gaadata` and `/data` overmounting. They are completely unnecessary when you could directly specify to the UI where to look. Reasoning for some of the changes are included as comments over specific lines.

BTW I haven't tested launching games with RA from stock UI, since I haven't changed the intercept script and it doesn't seem to refer to any overmounting locations.