### PR TITLE
Add .iso to intercepted formats

### DIFF
--- a/Payload/bleemsync/etc/bleemsync/SUP/scripts/intercept
+++ b/Payload/bleemsync/etc/bleemsync/SUP/scripts/intercept
@@ -48,6 +48,7 @@ intercept_file_formats=(    # alternative PCSX ReARMed game formats
   "m3u"
   "pbp"
   "img"
+  "iso"
   "mdf"
   "toc"
   "cbn"


### PR DESCRIPTION
Since .iso are the same as .img, and PCSX doesn't really do anything special when it encounters .img, it should handle .iso.