### PR TITLE
Create databases folder if not exist

### DIFF
--- a/Payload/bleemsync/etc/bleemsync/FUNC/0050_bleemsync.funcs
+++ b/Payload/bleemsync/etc/bleemsync/FUNC/0050_bleemsync.funcs
@@ -242,6 +242,14 @@ execute_bleemsync_func(){
     cp /gaadata/1/pcsx.cfg "$bleemsync_path/etc/bleemsync/SYS/defaults"
   [ ! -f "$bleemsync_path/etc/bleemsync/CFG/system.pre" ] && \
     cp "$bleemsync_path/etc/bleemsync/SUP/scripts/system.pre" "$bleemsync_path/etc/bleemsync/CFG"
+  
+  # Check if this is a new install
+  if [ ! -f "$bleemsync_path/etc/bleemsync/SYS/databases/regional.db" ]; then
+    echo "[BLEEMSYNC](INFO) $bleemsync_path/etc/bleemsync/SYS/databases/regional.db does NOT EXIST"
+    echo "[BLEEMSYNC](INFO) This may be a new install. Creating databases folder"
+    mkdir -p "$bleemsync_path/etc/bleemsync/SYS/databases"
+  fi
+    
 #-----------------------------------------------------------------------------#
   start=$(date +%s%N)
 


### PR DESCRIPTION
* Create databases folder if it does not exist to enable UI to auto generate blank database on first launch