### PR TITLE
Refine /media game mounting logic

### DIFF
--- a/Payload/bleemsync/etc/bleemsync/FUNC/0050_bleemsync.funcs
+++ b/Payload/bleemsync/etc/bleemsync/FUNC/0050_bleemsync.funcs
@@ -141,6 +141,9 @@ setup_StockUI() {
   for game in "${media_game_ids[@]}"; do
     ln -s "${mountpoint}/games/${game}/" "${VOL_GAADATA}"
     ln -s "${mountpoint}/games/${game}/" "${VOL_DATAPCSX}"
+    # Ensure .pcsx/pcsx.cfg is present
+    mkdir -p "${mountpoint}/games/${game}/.pcsx"
+    [ ! -f "${mountpoint}/games/${game}/.pcsx/pcsx.cfg" ] && cp "$bleemsync_path/etc/bleemsync/SYS/defaults/pcsx.cfg" "${mountpoint}/games/${game}/.pcsx/pcsx.cfg"
   done
 
   if [ `find "${mountpoint}/games/"* -maxdepth 0 -type d | wc -l` -ne $media_game_ids ]; then
@@ -215,11 +218,7 @@ setup_StockUI() {
   # Overmount the stock DB now that we're done using it
   mount -o bind "${VOL_GAADATA}/databases/regional.db" /gaadata/databases/regional.db
 #-----------------------------------------------------------------------------#
-  # Ensure .pcsx/pcsx.cfg is present
-  for game in "${mountpoint}/games/"*/; do
-    mkdir -p "${game}.pcsx"
-    [ ! -f "${game}.pcsx/pcsx.cfg" ] && cp "$bleemsync_path/etc/bleemsync/SYS/defaults/pcsx.cfg" "${game}.pcsx/pcsx.cfg"
-  done
+  
 }
 ###############################################################################
 

--- a/Payload/bleemsync/etc/bleemsync/FUNC/0050_bleemsync.funcs
+++ b/Payload/bleemsync/etc/bleemsync/FUNC/0050_bleemsync.funcs
@@ -218,7 +218,6 @@ setup_StockUI() {
   # Overmount the stock DB now that we're done using it
   mount -o bind "${VOL_GAADATA}/databases/regional.db" /gaadata/databases/regional.db
 #-----------------------------------------------------------------------------#
-  
 }
 ###############################################################################
 

--- a/Payload/bleemsync/etc/bleemsync/FUNC/0050_bleemsync.funcs
+++ b/Payload/bleemsync/etc/bleemsync/FUNC/0050_bleemsync.funcs
@@ -137,10 +137,16 @@ setup_StockUI() {
   ln -s /usr/sony/bin/plugins "${VOL_DATAPCSX}"
 
   # Link games on /media
-  for game in "${mountpoint}/games/"*/; do
-    ln -s "${game}" "${VOL_GAADATA}"
-    ln -s "${game}" "${VOL_DATAPCSX}"
+  media_game_ids=(`"$bleemsync_path/bin/sqlite3" "$bleemsync_path/etc/bleemsync/SYS/databases/regional.db" -cmd "SELECT GAME_ID FROM MENU_ENTRIES" ".quit"`)
+  for game in "${media_game_ids[@]}"; do
+    ln -s "${mountpoint}/games/${game}/" "${VOL_GAADATA}"
+    ln -s "${mountpoint}/games/${game}/" "${VOL_DATAPCSX}"
   done
+
+  if [ `find "${mountpoint}/games/"* -maxdepth 0 -type d | wc -l` -ne $media_game_ids ]; then
+    echo "[BLEEMSYNC](WARN) You have more folders in ${mountpoint}/games/ than are in the BleemSync database." 
+    echo "[BLEEMSYNC](WARN) Do not manually add games to this folder. Remove any manually created folders and add them via the BleemSync web interface."
+  fi
 
   # Force intercept to allow launching custom scripts from stock UI
   mount -o bind "$bleemsync_path/etc/bleemsync/CFG/system.pre" "/usr/sony/share/data/preferences/system.pre"


### PR DESCRIPTION
* Existing logic symlinked all folders in /media/games to the temp locations in /var/volatile. This results in issues should the user have manually created numbered folders within /media/games when the script attempts to merge stock games with the media games. This also resulted in a pcsx.cfg being created in any folder within /media/games
* New logic will only symlink a folder in /media/games if it also exists in the BleemSync database, and will also only create a pcsx.cfg in these folders. A warning will be output to the log if the process finds the user has other folders in here advising them to remove them.

eg.
```
[BLEEMSYNC](INFO) launching stock ui
[BLEEMSYNC](PROFILE) BleemSync tmpfs mounting took: 14ms to execute
[BLEEMSYNC](WARN) You have more folders in /media/games/ than are in the BleemSync database.
[BLEEMSYNC](WARN) Do not manually add games to this folder. Remove any manually created folders and add them via the BleemSync web interface.
[BLEEMSYNC](PROFILE) BleemSync tmpfs symbolic linking took: 146ms to execute
[BLEEMSYNC](INFO) EMMC Count 20 Media Count 2
[BLEEMSYNC](PROFILE) BleemSync EMMC + USB dyna link took: 526ms to execute
```
