### PR TITLE
Fix: Disable power button when RA is stock emulator

### DIFF
--- a/Payload/bleemsync/etc/bleemsync/SUP/scripts/intercept
+++ b/Payload/bleemsync/etc/bleemsync/SUP/scripts/intercept
@@ -185,10 +185,12 @@ if [ "$launch_ra_from_stock_UI" = "1" ]; then
   esac
   end=$(date +%s%N)
   echo "[INTERCEPT](PROFILE) up to launching RetroArch took: $(((end-start)/1000000))ms to execute"
+  echo -n 2 > /data/power/disable
   link_ra_memory_cards
   launch_retroarch_from_StockUI
   exit_checkSaveState
   resume_ui_menu
+  echo -n 1 > /data/power/disable
   exit 0
 fi
 


### PR DESCRIPTION
* If the system is turned off via the power button while a game is playing played via stock UI with RA as the emulator, then the proper shutdown procedure is not followed and the system is suspended (leaving intercept, retroarch processes). If the user turns the system back on retroarch will continue running in the background and/or the new instance of stock ui may hang.
* Until this can be properly handled, disable the power button while a game is being played via stock UI with RA as the emulator. The user will need to quit back to stock ui and then press the power button. (quit via the RA menu, or by pressing RESET).