### PR TITLE
Fix: Audio glitching in Stock UI RetroArch

### DIFF
--- a/Payload/bleemsync/etc/bleemsync/SUP/scripts/intercept
+++ b/Payload/bleemsync/etc/bleemsync/SUP/scripts/intercept
@@ -99,6 +99,8 @@ fi
 echo "[INTERCEPT](INFO) The current working directory: $PWD"
 
 suspend_ui_menu
+# auto_dimmer causes audio glitching in RetroArch
+killall -s TERM auto_dimmer &> /dev/null
 intercept_command=""
 found_cdfile=false
 


### PR DESCRIPTION
* auto_dimmer process seems to cause audio glitching in RetroArch if they are running at the same time