### PR TITLE
Add ISO/CSO handling to carousel

### DIFF
--- a/0030_retroarch.funcs
+++ b/0030_retroarch.funcs
@@ -1,0 +1,220 @@
+#!/bin/sh
+#
+#  Copyright 2019 ModMyClassic (https://modmyclassic.com/license)
+#
+#  This program is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+###############################################################################
+# BleemSync Function Library - RetroArch
+# ModMyClassic.com / https://discordapp.com/invite/8gygsrw
+###############################################################################
+
+### LOCAL VARIABLES ###########################################################
+ra_save_path="/tmp/ra_save"
+ra_savestate_path="/tmp/ra_savestate"
+###############################################################################
+
+### LOCAL FUNCTIONS ###########################################################
+
+### UI_MENU -> retroarch INTERACTION FUNCTIONS ################################
+
+#  The follow variables will need to have been gathered from an intercept script
+#  prior to these functions being called
+#
+#
+#  intercept_game_path=""     # The full path to the launching game file (follows argument -cdfile)
+#  intercept_game_dir=""      # The directory game launched from - should be /data/AppData/sony/title
+#  intercept_game_id=""       # The file name of the game minus the extension (ie. SCUS-0001)
+#  intercept_game_ext=""      # The extension of game minus . (ie. cue)
+#  intercept_save_state=false # Set to true if ui_menu launches with -load
+
+launch_RA_from_StockUI_PPSSPP(){
+
+   start=$(date +%s%N)
+   echo "[BLEEMSYNC](INFO) Launching Retroarch PPSSPP breakout from the ui_menu"
+   #Not doing that stuff so much
+   rm -f "$runtime_log_path/retroarch.log"
+   [ ! -f "$retroarch_path/retroarch" ] && break #FAIL
+   #skip SHIT
+
+   echo "[BLEEMSYNC](INFO)  retroarch path: $retroarch_path"
+    
+   mkdir -p "/tmp/ra_cache"
+   chmod +x "$retroarch_path/retroarch"
+   export HOME="$retroarch_path"
+
+   # Launch retroarch
+   echo "[BLEEMSYNC](INFO) Launching Retroarch for game $intercept_game_path"
+   end=$(date +%s%N)
+   echo "[BLEEMSYNC](PROFILE) Retroarch launch_RA_from_StockUI_PPSSPP function took: $(((end-start)/1000000))ms to execute (up to launching RA exec)"
+   $retroarch_path/retroarch -v -L "$retroarch_path/.config/retroarch/cores/ppsspp_libretro.so" "$intercept_game_path" &> "$runtime_log_path/retroarch.log"
+   echo "[BLEEMSYNC](INFO) RetroArch exit code $?"
+   rm -fr "/tmp/ra_cache"
+}
+
+launch_retroarch_from_StockUI(){
+  start=$(date +%s%N)
+  echo "[BLEEMSYNC](INFO) Launching RetroArch from ui_menu"
+  #  Check RA Exists and is configured correctly
+  rm -f "$runtime_log_path/retroarch.log"
+  [ ! -f "$retroarch_path/retroarch" ] && break #FAIL
+  if [ ! -f "$retroarch_path/system/scph102b.bin" ]; then
+    cp -f "/gaadata/system/bios/romw.bin" "$retroarch_path/system/scph102b.bin"
+    echo "[BLEEMSYNC](INFO) copied romw.bin to scph102b.bin for RA PCSX"
+  fi
+  mkdir -p "/tmp/ra_cache"
+  chmod +x "$retroarch_path/retroarch"
+  if [ -d "$ra_savestate_path" ]; then
+      rm -fr "$ra_savestate_path"
+  fi
+  mkdir -p "$ra_savestate_path"
+  link_ra_savestates
+  export HOME="$retroarch_path"
+  #  Check if this is a Save State load
+  if [ "$intercept_save_state" = true ]; then
+    echo "[BLEEMSYNC](INFO) This is a Save State load"
+    if [ ! -f "/data/AppData/sony/pcsx/.pcsx/sstates/${intercept_game_id}.000" ]; then
+      if [ -f "/data/AppData/sony/pcsx/.pcsx/sstates/${intercept_game_id}.000.res" ]; then
+        # Stock PCSX trims spaces out of save state names if they exist, and Stock UI cannot restore save states
+        # which have a space in the name (despite being able to save them!) This save state has a space so copy it manually
+        cp "/data/AppData/sony/pcsx/.pcsx/sstates/${intercept_game_id}.000.res" "/data/AppData/sony/pcsx/.pcsx/sstates/${intercept_game_id}.000"
+      fi
+    fi
+    mv "/data/AppData/sony/pcsx/.pcsx/sstates/${intercept_game_id}.000" "${ra_savestate_path}/${intercept_game_id}.state.auto"
+  fi
+
+  #  Launch retroarch
+  echo "[BLEEMSYNC](INFO) Launching RetroArch for game $intercept_game_path"
+  end=$(date +%s%N)
+  echo "[BLEEMSYNC](PROFILE) RetroArch launch_retroarch_from_StockUI function took: $(((end-start)/1000000))ms to execute (up to launching RetroArch executable)"
+  $retroarch_path/retroarch -v -L "$retroarch_path/.config/retroarch/cores/pcsx_rearmed_libretro.so" "$intercept_game_path" &> "$runtime_log_path/retroarch.log"
+  echo "[BLEEMSYNC](INFO) RetroArch exit code $?"
+  save_ra_savestates
+  rm -fr "/tmp/ra_cache"
+}
+
+exit_checkSaveState(){
+  # This function should only be called from the intercept script after retroarch exits
+  start=$(date +%s%N)
+  echo "[BLEEMSYNC](INFO) checking for auto save state on retroarch exit"
+
+  # An auto save state is created automatically, but what if the game disc was changed since
+  # retroarch was originally launched. Check that the last saved state matches the ID of the launching
+  # game
+
+  ra_last_game=`ls -t "${ra_savestate_path}/"*.auto | head -1`
+
+  if [ x"$ra_last_game" = x"" ]; then
+    echo "[BLEEMSYNC](INFO) no auto save state exists"
+    end=$(date +%s%N)
+    echo "[BLEEMSYNC](PROFILE) RetroArch check for save state took: $(((end-start)/1000000))ms to execute"
+    return 0
+  fi
+
+  ra_last_game="${ra_last_game##*/}"          # Remove leading directories
+  ra_last_game="${ra_last_game%.state.auto}"  # Remove trailing file extension .state.auto
+
+  if [ ! "$ra_last_game" = "$intercept_game_id" ]; then
+    #  The last save state was for a different game, check if this disc belongs to the launching game
+    #  If it does then a disc swap has occured, so update the game ids so the correct save state
+    #  data is passed to ui_menu state is from a game which is different to the launched game"
+    if [ -f "/data/AppData/sony/title/${ra_last_game}.${intercept_game_ext}" ]; then
+      echo "[BLEEMSYNC](INFO) ${ra_last_game}.${intercept_game_ext} exists and belongs to the launching game, updating save state"
+      intercept_game_path="/data/AppData/sony/title/${ra_last_game}.${intercept_game_ext}"
+      intercept_game_id="$ra_last_game"
+      echo "[BLEEMSYNC](INFO) New game path: $intercept_game_path"
+      echo "[BLEEMSYNC](INFO) New Game ID: $intercept_game_id"
+    else
+      echo "[BLEEMSYNC](INFO) the last played game does not appear to belong to the game we launched from, so we'll ignore it [${ra_last_game}.${intercept_game_ext}]"
+    fi
+  fi
+
+  #  Check if an auto save state exists and then move it to the correct location for ui_menu to handle
+  if [ -f "$ra_savestate_path/${intercept_game_id}.state.auto" ]; then
+    echo "[BLEEMSYNC](INFO) an auto save state exists"
+    #  Create filename.txt
+    echo "$intercept_game_path" > /data/AppData/sony/pcsx/.pcsx/filename.txt
+    echo "$intercept_game_id" >> /data/AppData/sony/pcsx/.pcsx/filename.txt
+    #  Create save state folders
+    mkdir -p "/data/AppData/sony/pcsx/.pcsx/sstates"
+    mkdir -p "/data/AppData/sony/pcsx/.pcsx/screenshots"
+    #  Move save state files
+    mv "${ra_savestate_path}/${intercept_game_id}.state.auto" "/data/AppData/sony/pcsx/.pcsx/sstates/${intercept_game_id}.000"
+    mv "${ra_savestate_path}/${intercept_game_id}.state.auto.png" "/data/AppData/sony/pcsx/.pcsx/screenshots/${intercept_game_id}.png"
+  fi
+
+  # Remove the temporary save state folder. This is only used when Stock UI is launching RetroArch
+  # and only for the current game
+  rm -fR "$ra_savestate_path"
+  end=$(date +%s%N)
+  echo "[BLEEMSYNC](PROFILE) RetroArch check for save state took: $(((end-start)/1000000))ms to execute"
+}
+
+link_ra_memory_cards(){
+  #  This function will link ui_menu and retroarch memory cards
+  #  ui_menu memory cards take precedence
+  start=$(date +%s%N)
+  echo "[BLEEMSYNC](INFO) linking ui_menu memory cards to RetroArch"
+  if ls -la | grep -i ".pcsx ->"; then
+    if [ ! -f "/data/AppData/sony/pcsx/.pcsx/memcards/card1.mcd" ]; then
+      mkdir -p "/data/AppData/sony/pcsx/.pcsx/memcards"
+      cp "/usr/sony/share/data/memcard/card.mcd" "/data/AppData/sony/pcsx/.pcsx/memcards/card1.mcd"
+    fi
+
+    if [ -d "$ra_save_path" ]; then
+      # This is a temporary save location for use by the current RetroArch game only
+      rm -fr "$ra_save_path"
+    fi
+    mkdir -p "$ra_save_path"
+    ln -sf "/data/AppData/sony/pcsx/.pcsx/memcards/card1.mcd" "${ra_save_path}/${intercept_game_id}.srm"
+
+    # RetroArch creates a memory card per game, which means all possible game discs need to be linked back to
+    # /data/AppData/sony/pcsx/.pcsx/memcards/card1.mcd. If this isn't done then each individual disc will have its
+    # own memory card
+    #
+    # This is rather brute force at the moment, but iterate through each file in the directory and create a memory card symlink
+    for e in /data/AppData/sony/title/*; do
+      if [ -f "$e" ]; then
+        temp_id="${e##*/}"
+        temp_id="${temp_id%.*}"
+        ln -sf "/data/AppData/sony/pcsx/.pcsx/memcards/card1.mcd" "${ra_save_path}/${temp_id}.srm"
+      fi
+    done
+  fi
+  end=$(date +%s%N)
+  echo "[BLEEMSYNC](PROFILE) RetroArch link memory cards took: $(((end-start)/1000000))ms to execute"
+}
+
+link_ra_savestates(){
+  # This function will link relevant RetroArch save states into the temporary save state location
+  # which will enable the additional multiple save slot functionality RetroArch provides when
+  # launched from the Stock UI
+  start=$(date +%s%N)
+  echo "[BLEEMSYNC](INFO) linking other RetroArch save states into temporary location"
+  find "${retroarch_path}/savestates/" -name "${intercept_game_id}.state*" -a ! -name "${intercept_game_id}.state.*" -maxdepth 1 -type f -exec ln -sf "{}" "$ra_savestate_path" +
+  end=$(date +%s%N)
+  echo "[BLEEMSYNC](PROFILE) link_ra_save_states took: $(((end-start)/1000000))ms to execute"
+}
+
+save_ra_savestates(){
+  # This function will move any save states, other than auto save states, that may have been created
+  # during this session back into the main RetroArch save state folder
+  start=$(date +%s%N)
+  echo "[BLEEMSYNC](INFO) moving other RetroArch save states back to the main RetroArch location"
+  find "$ra_savestate_path" -name "*.state*" -a ! -name "*state.*" -maxdepth 1 -type f -exec mv "{}" "${retroarch_path}/savestates/" +
+  end=$(date +%s%N)
+  echo "[BLEEMSYNC](PROFILE) save_ra_savestates took: $(((end-start)/1000000))ms to execute"
+}
+
+###############################################################################

--- a/intercept
+++ b/intercept
@@ -1,0 +1,224 @@
+#!/bin/sh
+#
+#  Copyright 2019 ModMyClassic (https://modmyclassic.com/license)
+#
+#  This program is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+###############################################################################
+# PlayStation Classic Stock UI to Emulator Intercept Script
+# ModMyClassic.com / https://discordapp.com/invite/8gygsrw
+###############################################################################
+
+### CHECK FOR LAUNCH SCRIPT ###################################################
+# If launch script exists run it instead of pcsx/RA
+if [ -f "/data/AppData/sony/title/launch.sh" ]; then
+  echo "[INTERCEPT](INFO) launch.sh exists"
+  exec "/data/AppData/sony/title/launch.sh" 
+  # Shouldn't get to here
+  exit 1
+fi
+
+start=$(date +%s%N)
+### LOAD CONFIGURATION ########################################################
+source "/var/volatile/bleemsync.cfg"
+
+### LOAD FUNCTION LIBRARIES ###################################################
+source "/media/bleemsync/etc/bleemsync/FUNC/0030_retroarch.funcs"
+
+### INTERCEPT VARIABLES #######################################################
+intercept_pcsx_path="/usr/sony/bin/pcsx"
+intercept_game_path=""
+intercept_game_dir=""
+intercept_game_id=""
+intercept_game_ext=""
+intercept_game_alternative_path=""
+intercept_save_state=false
+intercept_file_formats=(    # alternative PCSX ReARMed game formats
+  "m3u"
+  "pbp"
+  "img"
+  "mdf"
+  "toc"
+  "cbn"
+  "iso"
+  "cso"
+) ##++ iso and cso
+
+ui_menu_pid=""
+
+### INTERCEPT FUNCTIONS #######################################################
+suspend_ui_menu() {
+  start_suspend=$(date +%s%N)
+  ui_menu_pid=`ps|grep ui_menu|grep -v grep|awk '{print $1}'`
+  if [ `echo "$ui_menu_pid" | wc -l` -ne 1 ]; then
+    echo "[INTERCEPT](ERROR) unable to suspend ui_menu"
+    echo "[INTERCEPT](ERROR) ui_menu is either not running, or more than one instance is running"
+    echo "[INTERCEPT](ERROR) ui_menu_pid: ${ui_menu_pid}"
+    ui_menu_pid=""
+  else
+    echo "[INTERCEPT](INFO) suspending ui_menu (PID ${ui_menu_pid})"
+    kill -STOP "$ui_menu_pid"
+  fi
+  end_suspend=$(date +%s%N)
+  echo "[INTERCEPT](PROFILE) suspending ui_menu took: $(((end_suspend-start_suspend)/1000000))ms to execute"
+}
+
+resume_ui_menu() {
+  start_suspend=$(date +%s%N)
+  if [ ! "$ui_menu_pid" = "" ]; then
+    echo "[INTERCEPT](INFO) resuming ui_menu (PID ${ui_menu_pid})"
+    kill -CONT "$ui_menu_pid"
+    ui_menu_pid=""
+  fi
+  end_suspend=$(date +%s%N)
+  echo "[INTERCEPT](PROFILE) resuming ui_menu took: $(((end_suspend-start_suspend)/1000000))ms to execute"
+}
+
+### START INTERCEPT SCRIPT ####################################################
+# This should be launched directly from ui_menu by
+# substituing the sPcsxExecPath in /usr/sony/share/data/preferences/system.pre
+# with the path to this script
+###############################################################################
+echo "[INTERCEPT](INFO) Starting PS Classic Intercept"
+if [ "$#" -ge 1 ]; then
+  echo "[INTERCEPT](INFO) There are $# parameters:"
+  echo "[INTERCEPT](INFO) $*"
+else
+  echo "[INTERCEPT](INFO) There are no parameters" 
+fi
+
+echo "[INTERCEPT](INFO) The current working directory: $PWD"
+
+pspFlag=0 #I'm deliberately going somewhere, so I don't f-up all the hard work you have already done, guys
+
+suspend_ui_menu
+intercept_command=""
+found_cdfile=false
+
+# Loop through each argument to pull out information relating to which game is being loaded
+# and whether this is a Save State load
+start_arg=$(date +%s%N)
+for arg in "$@"
+do
+
+  if [ "$found_cdfile" = true ]; then
+
+    intercept_game_path="$arg"
+    echo "[INTERCEPT](INFO) Game full path: ${intercept_game_path}"
+    intercept_game_dir="${arg%/*}/"
+    echo "[INTERCEPT](INFO) Game directory: ${intercept_game_dir}"
+
+    intercept_game_id="${arg##*/}"
+    intercept_game_id="${intercept_game_id%.*}"
+    echo "[INTERCEPT](INFO) Game ID: $intercept_game_id"
+    intercept_game_ext="${arg##*.}"
+    echo "[INTERCEPT](INFO) Game extension: $intercept_game_ext"
+
+    # Check if the game exists in an alternative format
+    # The game path always has .cue appened to the BASENAME field of the DISC table in regional.db
+    # EXCEPT when the game is launched from a Save State. In this case the Game Path is determined from
+    # the first line of filename.txt.res in the games PCSX data directory (ie. /data/AppData/sony/pcsx/1/.pcsx/filename.txt.res)
+    if [ "$intercept_save_state" = false ]; then
+
+      start_alt=$(date +%s%N)
+      for f in "${intercept_file_formats[@]}"; do
+        intercept_game_alternative_path="${arg%.cue}.${f}"
+
+echo "[INTERCEPT](INFO) alt path: $intercept_game_alternative_path"
+
+        if [ -f "$intercept_game_alternative_path" ]; then
+          echo "[INTERCEPT](INFO) Alternative game format exists (${f}), this will be used instead of the .cue"
+          arg="$intercept_game_alternative_path"
+          intercept_game_path="$arg"
+          intercept_game_ext="${f}"
+##
+if [ "${intercept_game_ext}" = "iso" ]; then
+pspFlag=1
+fi
+
+if [ "${intercept_game_ext}" = "cso" ]; then
+pspFlag=1
+fi
+##
+          echo "[INTERCEPT](INFO) New Game full path: ${intercept_game_path}"
+          echo "[INTERCEPT](INFO) New Game extension: ${intercept_game_ext}"
+          break
+        fi
+      done
+      end_alt=$(date +%s%N)
+      echo "[INTERCEPT](PROFILE) finding alternative game formats took: $(((end_alt-start_alt)/1000000))ms to execute"
+    fi
+    found_cdfile=false
+    continue
+  fi
+
+  case $arg in
+    -cdfile)
+      found_cdfile=true
+      continue
+      ;;
+
+     -load)
+      echo "[INTERCEPT](INFO) This is a Save State load"
+      intercept_save_state=true
+      ;;
+  esac
+
+  #   Build the new parameters for PCSX
+  intercept_command="${intercept_command} ${arg}"
+
+done
+end_arg=$(date +%s%N)
+echo "[INTERCEPT](PROFILE) extracting arguments took: $(((end_arg-start_arg)/1000000))ms to execute"
+
+
+if [ "$launch_ra_from_stock_UI" = "1" ]; then
+  echo "[INTERCEPT](INFO) RetroArch is enabled as the emulator"
+  # Swap stock multi disc game path to an .m3u for better disc swap support in RetroArch
+  case "$intercept_game_id" in
+    SCUS-94163|SLPM-86114|SLPS-01057|SLPS-01230|SLUS-00594)
+      if [ "$intercept_game_ext" = "cue" ] && [ "$intercept_save_state" = false ] ; then
+        echo "[INTERCEPT](INFO) This is a stock multi disc game with no .m3u. An .m3u is needed for the best multi disc experience within RetroArch"
+        if [ -f "$bleemsync_path/etc/bleemsync/SUP/retroarch/title/${intercept_game_id}.m3u" ]; then
+          intercept_game_path="$bleemsync_path/etc/bleemsync/SUP/retroarch/title/${intercept_game_id}.m3u"
+          intercept_game_ext="m3u"
+          echo "[INTERCEPT](INFO) New Game full path: ${intercept_game_path}"
+          echo "[INTERCEPT](INFO) New Game extension: ${intercept_game_ext}"
+        else
+          echo "[INTERCEPT](ERROR) an .m3u does not exist at $bleemsync_path/etc/bleemsync/SUP/retroarch/title/${intercept_game_id}.m3u"
+        fi 
+      fi
+      ;;
+  esac
+  end=$(date +%s%N)
+  echo "[INTERCEPT](PROFILE) up to launching RetroArch took: $(((end-start)/1000000))ms to execute"
+if [ $pspFlag = 1 ]; then
+ launch_RA_from_StockUI_PPSSPP ##other path to RA execution
+else
+  link_ra_memory_cards
+  launch_retroarch_from_StockUI
+  exit_checkSaveState
+fi
+
+  resume_ui_menu
+  exit 0
+fi
+
+echo "[INTERCEPT](INFO) Launching $intercept_pcsx_path $intercept_command -cdfile $intercept_game_path"
+end=$(date +%s%N)
+echo "[INTERCEPT](PROFILE) up to launching stock pcsx took: $(((end-start)/1000000))ms to execute"
+"$intercept_pcsx_path" $intercept_command -cdfile "$intercept_game_path"
+resume_ui_menu
+# Exit returning the pcsx exit code
+exit $?


### PR DESCRIPTION
This modifies the extensions in the intercept flags iso/cso games and kicks them to a separate function for retroarch execution, with the ppsspp core