### PR TITLE
Add missing option to BS config model

### DIFF
--- a/BleemSync.Extensions.PlayStationClassic/BleemSync.Extensions.PlayStationClassic.Core/Models/PayloadConfig.cs
+++ b/BleemSync.Extensions.PlayStationClassic/BleemSync.Extensions.PlayStationClassic.Core/Models/PayloadConfig.cs
@@ -166,5 +166,11 @@ namespace BleemSync.Extensions.PlayStationClassic.Core.Models
         [DefaultValue(true)]
         [Display(Name = "If TRUE then play boot menu music WAV loop")]
         public bool BootMenuMusic { get; set; }
+
+        [IniProperty(Name = "usb_only")]
+        [IniSection(Name = "not_recommended")]
+        [DefaultValue(false)]
+        [Display(Name = "If TRUE do not install bootloader payload")]
+        public bool UsbOnly { get; set; }
     }
 }


### PR DESCRIPTION
The missing option is preventing bootloader from updating.