### PR TITLE
Fix game-manager.js to allow deleting empty game folders

### DIFF
--- a/BleemSync/wwwroot/lib/bleemsync/game-manager.js
+++ b/BleemSync/wwwroot/lib/bleemsync/game-manager.js
@@ -139,8 +139,18 @@
 
     EditGame(data) {
         var d = new Date();
+        
         // Reformat date so it would be set properly by browser
-        data.ReleaseDate = data.ReleaseDate.split('T')[0];
+        // Prevent error when loading a misconfigured (blank) game
+        if (data.ReleaseDate) {
+            data.ReleaseDate = data.ReleaseDate.split('T')[0];
+        }
+        
+        // If loading a misconfigured (blank) game, provide an indication of that in the name
+        if (!data.Name || data.Name === "") {
+            data.Name = "Empty game";
+        }
+        
         this._editGameForm.show().setViewModel(data);
         this._editGameForm.find('.cover-preview').attr('src', `/Games/GetLocalCoverByGameId/${data.Id}?v=${d.getTime()}`);
     }


### PR DESCRIPTION
Fixes #356 by working around the Javascript errors that prevented the edit window from opening for misconfigured (blank) games. This lets the window open and the user can manually delete these blank game configs.